### PR TITLE
[#31] Publish the error message when user has not enough credit

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "xml2js": "^0.4.19"
   },
   "devDependencies": {
+    "@types/amqplib": "^0.5.9",
     "chromedriver": "^2.37.0",
     "mocha-junit-reporter": "^1.13.0",
     "wdio-chromedriver-service": "^0.1.2"

--- a/types/ProcessNotifier.d.ts
+++ b/types/ProcessNotifier.d.ts
@@ -1,0 +1,46 @@
+declare module ProcessNotifier {
+  interface Start {
+    _id: string
+    callerId: string
+    timeStamp: number
+    steps: Array<{
+      componentId: string
+      status: string
+    }>
+  }
+
+  interface Progress {
+    componentId: string
+    processId: string
+    error: string | { message: string }
+  }
+
+  interface Error {
+    _id: string
+    error?: string
+  }
+
+  interface End {
+    _id: string
+  }
+
+  type Persist = PersistSuccess | PersistError
+
+  interface PersistSuccess {
+    componentId: string
+    processId: string
+    data: any
+  }
+
+  interface PersistError {
+    componentId: string
+    processId: string
+    error: string
+  }
+
+  interface ProcessCleaned {
+    // Actually Array<ProcessModel> but not declared yet
+    cleanedProcesses: Array<{}>
+  }
+}
+

--- a/types/amqp.d.ts
+++ b/types/amqp.d.ts
@@ -1,0 +1,6 @@
+import { Channel as BaseChannel } from 'amqplib'
+
+declare module amqp {
+  interface Channel extends BaseChannel {
+  }
+}

--- a/webServices/ProcessNotifier.js
+++ b/webServices/ProcessNotifier.js
@@ -1,0 +1,69 @@
+'use strict'
+
+class ProcessNotifier {
+  /**
+   * @param {amqp.Channel} amqpClient
+   * @param {string} workspaceId
+   */
+  constructor(amqpClient, workspaceId) {
+    this.amqpClient = amqpClient
+    this.workspaceId = workspaceId
+  }
+
+  /**
+   * @param {ProcessNotifier.Start} content
+   */
+  start(content) {
+    this.publish(`process-start`, content)
+  }
+
+  /**
+   * @param {ProcessNotifier.Progress} content
+   */
+  progress(content) {
+    this.publish(`process-progress`, content)
+  }
+
+  /**
+   * @param {ProcessNotifier.Error} content
+   */
+  error(content) {
+    this.publish(`process-error`, content)
+  }
+
+  /**
+   * @param {ProcessNotifier.End} content
+   */
+  end(content) {
+    this.publish(`process-end`, content)
+  }
+
+  /**
+   * @param {ProcessNotifier.Persist} content
+   */
+  persist(content) {
+    this.publish(`process-persist`, content)
+  }
+
+  /**
+   * @param {ProcessNotifier.ProcessCleaned} content
+   */
+  processCleaned(content) {
+    this.publish(`workflow-processCleaned`, content)
+  }
+
+  /**
+   * @param {string} key
+   * @param {*} content
+   * @private
+   */
+  publish(key, content) {
+    this.amqpClient.publish(
+      'amq.topic',
+      `${key}.${this.workspaceId}`,
+      new Buffer(JSON.stringify(content))
+    );
+  }
+}
+
+module.exports = ProcessNotifier

--- a/webServices/engine.js
+++ b/webServices/engine.js
@@ -444,7 +444,7 @@ class Engine {
       }
     } else {
       let fullError = new Error("Vous n'avez pas assez de credit");
-      //fullError.message = "Vous n'avez pas assez de credit";
+      this.amqpClient.publish("amq.topic", this.keyError, new Buffer(JSON.stringify({error: fullError.message})))
       this.RequestOrigineRejectMethode(fullError);
     }
   }


### PR DESCRIPTION
The error message was not sent when the user has not enough credit.
The engine throw the error but it was never transformed into a response for the client.

This commit does the following:

- Publish the error message trough AMQP when user has not enough credit

This PR resolves #31.