### PR TITLE
[#50] Correct Unicity table

### DIFF
--- a/static/tag/unicity-editor.tag
+++ b/static/tag/unicity-editor.tag
@@ -34,11 +34,9 @@
 
     this.addRow = function (e) {
       this.refs.unicityTableRef.data.push({})
-      //console.log(this.tags.zentable.data)
     }.bind(this);
 
     this.onSourceChange = function (e) {
-      console.log('ALLO');
       this.data.specificData.source = e.target.value;
     }.bind(this);
 
@@ -47,13 +45,14 @@
       this.refs.unicityTableRef.on('dataChanged', data => {
         this.data.specificData.unicityFields = data;
       });
+      this.refs.unicityTableRef.on('delRow', item => {
+        const unicityFields = this.data.specificData.unicityFields
+        unicityFields.splice(unicityFields.findIndex(_ => _.rowId === item.rowId), 1)
+      });
     });
     this.on('unmount', function () {
       RiotControl.off('item_current_changed', this.updateData);
     });
-
-    // this.fieldValueChange = function (e) {   console.log(e.target.value);   this.fieldValue = e.target.value;   console.log(this.currentRowId)   this.data.specificData.unicityFields[this.currentRowId]={field:this.fieldValue};   console.log("value
-    // change", this.data.specificData.unicityFields)   this.tags.zentable.data = this.data.specificData.unicityFields; }.bind(this);
   </script>
   <style scoped="scoped"></style>
 </unicity-editor>


### PR DESCRIPTION
The deletion of rows did not work on Unicity component table.
The reason was the `delRow` event was not called.

This commit does the following:

- Add handler to event `delRow`
- Remove unnecessary comments

This PR resolves #50.