### PR TITLE
[#49] Correct Property Matrix table

### DIFF
--- a/static/tag/properties-matrix-editor.tag
+++ b/static/tag/properties-matrix-editor.tag
@@ -34,11 +34,9 @@
 
     this.addRow = function (e) {
       this.refs.fieldsTableRef.data.push({})
-      //console.log(this.tags.zentable.data)
     }.bind(this);
 
     this.onAttributChange = function (e) {
-      //console.log('ALLO');
       this.data.specificData.attribut = e.target.value;
     }.bind(this);
 
@@ -47,13 +45,14 @@
       this.refs.fieldsTableRef.on('dataChanged', data => {
         this.data.specificData.fields = data;
       });
+      this.refs.fieldsTableRef.on('delRow', item => {
+        const fields = this.data.specificData.fields
+        fields.splice(fields.findIndex(_ => _.rowId === item.rowId), 1)
+      });
     });
     this.on('unmount', function () {
       RiotControl.off('item_current_changed', this.updateData);
     });
-
-    // this.fieldValueChange = function (e) {   console.log(e.target.value);   this.fieldValue = e.target.value;   console.log(this.currentRowId)   this.data.specificData.unicityFields[this.currentRowId]={field:this.fieldValue};   console.log("value
-    // change", this.data.specificData.unicityFields)   this.tags.zentable.data = this.data.specificData.unicityFields; }.bind(this);
   </script>
   <style scoped="scoped"></style>
 </properties-matrix-editor>


### PR DESCRIPTION
The deletion of rows did not work on Property matrix component table.
The reason was the `delRow` event was not called.

This commit does the following:

- Add handler to event `delRow`
- Remove unnecessary comments

This PR resolves #49.