### PR TITLE
[#140] Correct status error

### DIFF
--- a/main/client/static/store/workspaceStore.js
+++ b/main/client/static/store/workspaceStore.js
@@ -259,22 +259,20 @@ function WorkspaceStore (utilStore, stompClient, specificStoreList) {
   // --------------------------------------------------------------------------------
 
   this.create = function () {
-    return new Promise((resolve, reject) => {
-      this.utilStore.ajaxCall({
-        method: 'post',
-        url: '../data/core/workspaces/',
-        data: JSON.stringify({ workspace: this.workspaceCurrent })
-      }, true).then(data => {
-        console.log(data)
-        this.workspaceCollection.push(data)
-        console.log(this.workspaceCollection)
-        this.workspaceCurrent = data
-        this.workspaceCurrent.mode = 'edit'
-        resolve(this.workspaceCurrent)
-      }).catch(error => {
-        reject(error)
+    return this.utilStore.ajaxCall({
+      method: 'post',
+      url: '../data/core/workspaces/',
+      data: JSON.stringify({ workspace: this.workspaceCurrent })
+    }, true)
+      .then(createdWorkspace => {
+        this.load()
+        return createdWorkspace
       })
-    })
+      .then(createdWorkspace => {
+        this.workspaceCurrent = createdWorkspace
+        this.workspaceCurrent.mode = 'edit'
+        return this.workspaceCurrent
+      })
   } // <= create
 
   // --------------------------------------------------------------------------------


### PR DESCRIPTION
When creating a new workspace, the status was not displayed.
The reason was that the workspace creation does not give the exact same model than the list.
It is not really an error in the creation process nor in the list.

To avoid this issue, we force the reload of the whole list of workspaces.

This commit does the following:

* Correct the workspace `create` function on client side to reload the whole list

This PR resolves #140 