### PR TITLE
[#137] Correct login behavior

### DIFF
--- a/main/client/static/tag/login.tag
+++ b/main/client/static/tag/login.tag
@@ -409,12 +409,10 @@
     loginGoogle(e) {
       RiotControl.trigger('google_user_connect', this.user);
     }
+
     login(e) {
-      if ((this.user.password != undefined) && (this.user.email != undefined) && (this.user.email != "") && (this.user.email != "")) {
-        RiotControl.trigger('user_connect', this.user);
-      } else {
-        this.resultConnexion = "Remplissez votre email et mot de passe"
-      }
+      e.preventDefault()
+      RiotControl.trigger('user_connect', this.user);
     }
 
     this.isGoogleUser();


### PR DESCRIPTION
When the user tries to login, a strange behavior happen.
The user must enter his credentials twice.

After investigation, the reason was that the form was always sent as classic form.
We need to block the default browser behavior for the application to work as expected.

This commit does the following:

* Prevent default browser behavior
* Remove unnecessary validation

This PR resolves #137 .