### PR TITLE
[#138] Enables filters on second lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,10 @@ stop: docker-stop
 
 restart: docker-restart
 
-build: docker-build 
+build: docker-build
+
+test-build:
+	$(DOCKER_COMPOSE_TEST) build --no-cache
 
 test-start:
 	$(DOCKER_COMPOSE_TEST) run e2e bash ./wait-for-it.sh semanticbus:80 -t 45

--- a/main/client/static/tag/technicalComponentTable.tag
+++ b/main/client/static/tag/technicalComponentTable.tag
@@ -177,7 +177,6 @@
       flex-basis: 0px;
     }
     .containerFilter {
-      height: 2vh;
       width: 100%;
     }
     .containerValidate {

--- a/main/client/static/tag/zenTable.tag
+++ b/main/client/static/tag/zenTable.tag
@@ -1,8 +1,6 @@
 <zentable class="containerV {opts.zentableClass}" style="flex-grow:1;">
   <!-- header -->
-  <div class="containerH tableHeader" ref="tableHeader" >
-    <yield from="header"/>
-  </div>
+  <div class="containerH tableHeader" ref="tableHeader" ><yield from="header"/></div>
 
   <div class="containerV scrollable tableBody" ref="tableBodyContainer">
     <!--<div class="table scrollable" name="tableBody" ref="tableBody" ondragover={on_drag_over} ondrop={on_drop}>-->
@@ -283,6 +281,10 @@
       justify-content: center;
       height: 5vh;
       margin-bottom: 1vh;
+    }
+
+    .tableHeader:empty {
+      display: none;
     }
 
     .tableHeader > * {


### PR DESCRIPTION
The filters on the second line seemed to not working.
After investigation, the reason was that the zentable header was above the filters (but invisible).

We correct sizes of impacted elements.

This commit does the following:

* Remove height of filters (let browser to compute it automatically)
* Do not display the zentable header when it is empty (quick win)

This PR resolves #138 .