### PR TITLE
Add preview in Framacalc component

### DIFF
--- a/main/client/static/application.html
+++ b/main/client/static/application.html
@@ -8,9 +8,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <link href='https://fonts.googleapis.com/css?family=Ubuntu|Ubuntu+Mono' rel='stylesheet' type='text/css'>
   <link href='https://cdn.jsdelivr.net/semantic-ui/2.1.8/semantic.min.css' rel='stylesheet' type='text/css'>-->
+
   <link href='./css/flex.css' rel='stylesheet' type='text/css'>
   <link href='./css/main.css' rel='stylesheet' type='text/css'>
   <link href='./css/inputs.css' rel='stylesheet' type='text/css'>
+  <link href='./css/alert.css' rel='stylesheet' type='text/css'>
+  <link href='./css/table.css' rel='stylesheet' type='text/css'>
+
   <link href='./js/jsonEditor/dist/jsoneditor.min.css' rel='stylesheet' type='text/css'>
   <link href="./image/grappe-log-01.png" rel="icon" type="image/png">
   <link rel="stylesheet" href="./js/awesomplete-gh-pages/awesomplete.css" />
@@ -28,6 +32,7 @@
   <script src="https://cdn.jsdelivr.net/npm/webstomp-client@1.2.0/dist/webstomp.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.1.4/sockjs.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.5/jstree.min.js"></script>
+  <script src="https://unpkg.com/papaparse@4.6.3/papaparse.min.js"></script>
 
   <!--<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.4.0/Chart.min.js"></script>-->
   <!--<script src="https://cdnjs.cloudflare.com/ajax/libs/javascript-detect-element-resize/0.5.3/detect-element-resize.js"></script>-->
@@ -104,6 +109,7 @@
   <script type="riot/tag" src="tag/editorComponents/dataFlow/rest-api-get-editor.tag"></script>
   <script type="riot/tag" src="tag/editorComponents/dataFlow/rest-get-json-editor.tag"></script>
   <script type="riot/tag" src="tag/editorComponents/dataFlow/framacalc-get-csv-editor.tag"></script>
+  <script type="riot/tag" src="tag/editorComponents/dataFlow/framacalc-preview.tag"></script>
   <script type="riot/tag" src="tag/editorComponents/dataFlow/google-get-json-editor.tag"></script>
   <script type="riot/tag" src="tag/editorComponents/dataFlow/rest-api-post-editor.tag"></script>
   <script type="riot/tag" src="tag/editorComponents/dataFlow/post-consumer-editor.tag"></script>

--- a/main/client/static/css/alert.css
+++ b/main/client/static/css/alert.css
@@ -1,0 +1,18 @@
+.alert {
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 2px;
+  padding: 1rem;
+}
+
+.alert.alert-error {
+  border-color: #ffa39e;
+  background-color: #fff1f0;
+  color: #cf1322;
+}
+
+.alert.alert-warning {
+  border-color: #ffe58f;
+  background-color: #fffbe6;
+  color: #d48806;
+}

--- a/main/client/static/css/table.css
+++ b/main/client/static/css/table.css
@@ -1,0 +1,21 @@
+.table-preview {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.table-preview tr:nth-of-type(2n+1) {
+  background-color: rgb(238, 242, 249);
+}
+
+.table-preview tr:hover {
+  background-color: rgb(213, 218, 224);
+}
+
+.table-preview td {
+  padding: 5px;
+  text-align: center;
+}
+
+.table-preview td.truncated {
+  font-style: italic;
+}

--- a/main/client/static/tag/editorComponents/dataFlow/framacalc-get-csv-editor.tag
+++ b/main/client/static/tag/editorComponents/dataFlow/framacalc-get-csv-editor.tag
@@ -3,64 +3,65 @@
   <div class="contenaireH" style="margin-left:97%">
     <a href="https://github.com/assemblee-virtuelle/Semantic-Bus/wiki/Composant:-Framacalc" target="_blank"><img src="./image/help.png" alt="Aide" width="25px" height="25px"></a>
   </div>
+
   <!-- Titre du composant -->
   <div class="contenaireV title-component">{data.type}</div>
   <div>
     <div class="bar"/>
   </div>
+
   <!-- Description du composant -->
   <div class="title-description-component">{data.description}</div>
   <div>
     <div class="bar"/>
   </div>
-  <!-- Champ du composant -->
+
+  <!-- Champs du composant -->
   <div class="subtitle">Information de connexion à Framacalc.</div>
-  <label class="labelFormStandard">URL framacalc / Ethercalc:</label>
+
+  <label class="labelFormStandard" for="framacalcEditorKey">
+    URL framacalc / Ethercalc:
+  </label>
   <div class="cardInput">
-    <input class="inputComponents" placeholder=""type="text" name="keyInput" ref="keyInput" value={data.specificData.key}></input>
+    <input class="inputComponents" type="text" name="keyInput" id="framacalcEditorKey"
+           value={data.specificData.key} oninput={onKeyChange}
+    />
   </div>
-  <label class="labelFormStandard">Commencer à partir de la ligne (offset):</label>
+
+  <label class="labelFormStandard" for="framacalcEditorOffset">Commencer à partir de la ligne (offset, commence à 0):</label>
   <div class="cardInput">
-    <input class="inputComponents" placeholder=""type="text" name="offsetInput" ref="offsetInput"  value={data.specificData.offset}></input>
+    <input class="inputComponents" type="number" step="1" min="0" name="offsetInput" id="framacalcEditorOffset"
+           value={data.specificData.offset} oninput={onOffsetChange}
+    />
   </div>
+
+  <framacalc-preview
+    key={data.specificData.key}
+    offset={data.specificData.offset}
+  ></framacalc-preview>
+
   <script>
+    this.data = {}
 
-    this.data={};
+    this.onKeyChange = (event) => {
+      this.data.specificData.key = event.currentTarget.value
+    }
 
-    /*
-    Object.defineProperty(this, 'data', {
-       set: function (dataDef) {
-         this.data=dataDef;
-         this.update();
-       }.bind(this),
-       get: function () {
-        return this.data;
-      },
-      configurable: true
-    });
-    */
+    this.onOffsetChange = (event) => {
+      this.data.specificData.offset = event.currentTarget.value
+    }
 
-    this.updateData=function(dataToUpdate){
-      this.data=dataToUpdate;
-      console.log('data',this.data)
+    this.updateData = (dataToUpdate) => {
+      this.data = dataToUpdate;
       this.update();
-    }.bind(this);
+    }
 
-    this.on('mount', function () {
-      console.log(this.data.specificData)
-      this.refs.keyInput.addEventListener('change',function(e){
-        this.data.specificData.key=e.currentTarget.value;
-      }.bind(this));
+    this.on('mount', () => {
+      RiotControl.on('item_current_changed', this.updateData)
+    })
 
-
-      this.refs.offsetInput.addEventListener('change',function(e){
-        this.data.specificData.offset=e.currentTarget.value;
-      }.bind(this));
-      RiotControl.on('item_current_changed',this.updateData);
-    });
-    this.on('unmount', function () {
-      RiotControl.off('item_current_changed',this.updateData);
-    });
-
+    this.on('unmount', () => {
+      RiotControl.off('item_current_changed', this.updateData)
+    })
   </script>
 </framacalc-get-csv-editor>

--- a/main/client/static/tag/editorComponents/dataFlow/framacalc-preview.tag
+++ b/main/client/static/tag/editorComponents/dataFlow/framacalc-preview.tag
@@ -1,0 +1,112 @@
+<framacalc-preview>
+  <div class="outputSample">
+    <h2>Prévisualisation</h2>
+
+    <p>
+      Ci-dessous une prévisualisation des données qui seront utilisées durant le traitement.
+    </p>
+
+    <p if={loading}>
+      Chargement en cours, veuillez patienter.
+    </p>
+
+    <p if={!loading && error} class="alert alert-warning">
+      {error}
+    </p>
+
+    <table class="table-preview" if={!loading && !error}>
+      <tr each={ line in rows }>
+        <td each={ cell in line }>{cell}</td>
+      </tr>
+      <tr if={hasMore}>
+        <td colspan={ maxColumns } class="truncated">données tronquées</td>
+      </tr>
+    </table>
+  </div>
+
+  <script>
+    this.previousOpts = {}
+    this.loading = false
+    this.error = undefined
+    this.downloaded = undefined
+    this.rows = undefined
+    this.hasMore = false
+    this.maxColumns = 0
+
+    this.on('mount', () => this.reload())
+    this.on('update', () => this.reload())
+
+    this.reload = () => {
+      if (this.previousOpts.key !== this.opts.key) {
+        this.loadData(this.opts.key)
+      } else {
+        this.formatSample()
+      }
+      this.previousOpts = {...this.opts}
+    }
+
+    this.loadData = (key) => {
+      if (key !== undefined && key !== '') {
+        this.loading = true
+        this.error = undefined
+        fetch(this.normalizeUrl(key))
+          .then(response => {
+            if (response.status === 200) {
+              return response.text()
+            } else if (response.status === 404) {
+              return Promise.reject('NOT_FOUND')
+            } else {
+              return Promise.reject(response.text())
+            }
+
+          })
+          .then(body => {
+            // No change in url during downloading
+            if (this.opts.key === key) {
+              this.downloaded = Papa.parse(body).data
+              this.loading = false
+              this.formatSample()
+              this.update()
+            }
+          })
+          .catch(error => {
+            if (error === 'NOT_FOUND') {
+              this.error = 'La feuille de calcul n\'a pas été trouvée.'
+            } else {
+              this.error = `Une erreur est survenue lors de la récupération de la feuille de calcul: ${error}`
+            }
+            this.loading = false
+            this.update()
+          })
+      } else {
+        this.downloaded = undefined
+      }
+    }
+
+    this.normalizeUrl = (url) => {
+      if (url.startsWith('http')) {
+        if (url.endsWith('.csv')) {
+          return url
+        } else {
+          return `${url}.csv`
+        }
+      } else {
+        if (url.endsWith('.csv')) {
+          return `https://framacalc.org/${url}`
+        } else {
+          return `https://framacalc.org/${url}.csv`
+        }
+      }
+    }
+
+    this.formatSample = () => {
+      if (this.downloaded !== undefined) {
+        const offset = parseInt(this.opts.offset) || 0
+        this.rows = this.downloaded.slice(offset, offset + 10)
+        this.hasMore = this.downloaded.length - offset - 10 > 0
+        this.maxColumns = this.rows.reduce((acc, current) => Math.max(acc, current.length), 0)
+      }
+    }
+
+  </script>
+</framacalc-preview>


### PR DESCRIPTION
When configuring components, sometimes, it is complicated to understand what will be processed.
To improve user experience and help them to correctly configure their data,
we add a preview for Framacalc components.

This commit does the following:

* Add `papaparse` dependency
* Add `alert.css` and `table.css` files to define reusable CSS components
* Add `framacalc-preview`
* Use it into `framacalc-get-csv-editor`
* Simplify `framacalc-get-csv-editor`