### PR TITLE
Deeper focus export fixed

### DIFF
--- a/main/server/workspaceWebService.js
+++ b/main/server/workspaceWebService.js
@@ -141,6 +141,7 @@ module.exports = function (router) {
       return {
         workspaceId: req.params.id,
         specificData: c.specificData || {},
+        deeperFocusData: c.deeperFocusData || {},
         module: c.module,
         type: c.type,
         description: c.description,


### PR DESCRIPTION
Same error as before, when we export a JSON file, the deeper focus isn't on the file.

![Image](https://user-images.githubusercontent.com/63355855/233379237-5b45e74d-c12b-4cfb-8b8a-2a8f95b779ed.png)