### PR TITLE
release: v0.11.1 (security fix RCE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased] - security fix (RCE eval) — branche `security/remove-sift-and-secure-eval`
+## [0.11.1] - 2026-08-19
 
 ### Security
 
@@ -61,6 +61,7 @@
 - **Component search**: barre de recherche dans le catalogue de composants
 - **New category system**: réorganisation des catégories de composants
 
+[0.11.1]: https://github.com/assemblee-virtuelle/Semantic-Bus/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/assemblee-virtuelle/Semantic-Bus/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/assemblee-virtuelle/Semantic-Bus/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/assemblee-virtuelle/Semantic-Bus/compare/v0.9.0...v0.9.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-bus-monorepo",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "ETL style data middleware transformation embedded in an ESB for all kind of data",
   "private": true,
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/core",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Core module for Semantic Bus",
   "private": true,
   "main": "index.js",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/engine",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Processing engine module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/eval-service/package.json
+++ b/packages/eval-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/eval-service",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Service d'évaluation JavaScript isolé en container (dédié aux eval des transformations / $where).",
   "private": true,
   "main": "app.js",

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/main",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Main application module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/timer",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Timer scheduler module for Semantic Bus",
   "private": true,
   "main": "app.js",


### PR DESCRIPTION
## Résumé

Release **v0.11.1** — version corrigée incluant le correctif de sécurité (RCE via `eval`) et les améliorations de performance.

## Changements

- **CHANGELOG.md** : entrée `[0.11.1] - 2026-08-19` (détaillant le fix sécurité + perf)
- **Version bump** `0.11.0` → `0.11.1` sur :
  - `package.json` (racine)
  - `packages/{core,main,engine,timer,eval-service}/package.json`

## Note

Cette version est requise comme référence "patched version" pour le GitHub Security Advisory (GHSA/CVE) de la faille RCE.