### PR TITLE
release: v0.11.2 (bypass RCE lodash.template fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.11.2] - 2026-08-20
+
+### Security
+
+- **Correctif du bypass RCE `lodash.template`** (signalé par Maxim Yakovlev) : `lodash.template`
+  compilait son corps avec un `Function` du host realm, échappant au contexte vm → `import()`
+  chargeait des modules Node → RCE dans le eval-service.
+- **Whitelist par lib dans le validateur** (analyse statique, pas de Proxy) : les fonctions
+  statiques des libs exposées (lodash, he, dayjs, moment, Buffer, crypto) sont explicitement
+  autorisées ; toute autre méthode est bloquée.
+- **Réduction du scope d'exposition** : `Buffer`, `crypto`, `he` exposés en wrappers minimaux ;
+  `lodash` en whitelist stricte ; `dayjs`/`moment` méthodes statiques whitelistées.
+- **`import()` dynamique rejeté** dans le worker (`importModuleDynamically`).
+- **`fetch`/`WebSocket` strippés** (défense en profondeur).
+- **Retour au comportement Loki** : évaluation atomique par item, la boucle du `$where` est
+  gérée par l'engine (le container ne fait qu'une évaluation à la fois).
+
+### Fixed
+
+- `runWhereInWorker`/`runWhereInRemote` retirés (obsolètes — remplacés par l'éval atomique).
+- `crypto.randomBytes` exposé (cas prod).
+
 ## [0.11.1] - 2026-08-19
 
 ### Security
@@ -61,6 +83,7 @@
 - **Component search**: barre de recherche dans le catalogue de composants
 - **New category system**: réorganisation des catégories de composants
 
+[0.11.2]: https://github.com/assemblee-virtuelle/Semantic-Bus/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/assemblee-virtuelle/Semantic-Bus/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/assemblee-virtuelle/Semantic-Bus/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/assemblee-virtuelle/Semantic-Bus/compare/v0.9.1...v0.10.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-bus-monorepo",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "ETL style data middleware transformation embedded in an ESB for all kind of data",
   "private": true,
   "workspaces": [
@@ -9,7 +9,7 @@
   "scripts": {
     "test:all": "npm run test --workspaces",
     "test:core": "npm run test --workspace=packages/core",
-    "test:main": "npm run test --workspace=packages/main", 
+    "test:main": "npm run test --workspace=packages/main",
     "test:engine": "npm run test --workspace=packages/engine",
     "test:timer": "npm run test --workspace=packages/timer",
     "install:all": "npm install",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/core",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Core module for Semantic Bus",
   "private": true,
   "main": "index.js",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/engine",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Processing engine module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/eval-service/package.json
+++ b/packages/eval-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/eval-service",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Service d'évaluation JavaScript isolé en container (dédié aux eval des transformations / $where).",
   "private": true,
   "main": "app.js",

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/main",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Main application module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/timer",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Timer scheduler module for Semantic Bus",
   "private": true,
   "main": "app.js",


### PR DESCRIPTION
## Résumé

Release **v0.11.2** — version corrigée incluant le **bypass RCE `lodash.template`**.

## Contenu

- **Correctif bypass RCE** via `lodash.template` (host-realm Function + import) — signalé par Maxim Yakovlev
- **Whitelist par lib** dans le validateur (analyse statique)
- **Réduction du scope d'exposition** (Buffer, crypto, he, lodash, dayjs, moment)
- **Retour au comportement Loki** (évaluation atomique par item)
- **CHANGELOG** + bump version `0.11.2`

CI verte (les tests ont été validés sur la PR #458). Déployé en prod.