### PR TITLE
fix(deps): bump body-parser 2.2.0 → 2.3.0 (moderate DoS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "semantic-bus-monorepo",
-  "version": "0.11.0",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "semantic-bus-monorepo",
-      "version": "0.11.0",
+      "version": "0.11.2",
       "license": "GNUV3",
       "workspaces": [
         "packages/*"
@@ -12781,7 +12781,7 @@
     },
     "packages/core": {
       "name": "@semantic-bus/core",
-      "version": "0.11.0",
+      "version": "0.11.2",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.840.0",
         "@aws-sdk/lib-dynamodb": "^3.840.0",
@@ -12822,7 +12822,7 @@
     },
     "packages/engine": {
       "name": "@semantic-bus/engine",
-      "version": "0.11.0",
+      "version": "0.11.2",
       "license": "GNUV3",
       "dependencies": {
         "@influxdata/influxdb-client": "^1.33.2",
@@ -12830,7 +12830,7 @@
         "@semantic-bus/core": "file:../core",
         "amqp-connection-manager": "^4.1.14",
         "amqplib": "^0.10.8",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.3.0",
         "cheerio": "^1.1.0",
         "cldr-data": "^36.0.2",
         "clone": "^2.1.2",
@@ -12888,21 +12888,40 @@
       }
     },
     "packages/engine/node_modules/body-parser": {
-      "version": "2.2.0",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "packages/engine/node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "packages/engine/node_modules/buffer": {
@@ -13016,13 +13035,19 @@
       }
     },
     "packages/engine/node_modules/iconv-lite": {
-      "version": "0.6.3",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "packages/engine/node_modules/media-typer": {
@@ -13074,16 +13099,18 @@
       }
     },
     "packages/engine/node_modules/raw-body": {
-      "version": "3.0.0",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "packages/engine/node_modules/send": {
@@ -13129,20 +13156,39 @@
       }
     },
     "packages/engine/node_modules/type-is": {
-      "version": "2.0.1",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "packages/engine/node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "packages/eval-service": {
       "name": "@semantic-bus/eval-service",
-      "version": "0.11.0",
+      "version": "0.11.2",
       "dependencies": {
         "@semantic-bus/core": "file:../core",
         "cheerio": "^1.1.0",
@@ -13425,7 +13471,7 @@
     },
     "packages/main": {
       "name": "@semantic-bus/main",
-      "version": "0.11.0",
+      "version": "0.11.2",
       "license": "GNUV3",
       "dependencies": {
         "@semantic-bus/core": "file:../core",
@@ -13460,7 +13506,7 @@
     },
     "packages/timer": {
       "name": "@semantic-bus/timer",
-      "version": "0.11.0",
+      "version": "0.11.2",
       "license": "GNUV3",
       "dependencies": {
         "@semantic-bus/core": "file:../core",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -21,7 +21,7 @@
     "@semantic-bus/core": "file:../core",
     "amqp-connection-manager": "^4.1.14",
     "amqplib": "^0.10.8",
-    "body-parser": "^2.2.0",
+    "body-parser": "^2.3.0",
     "cheerio": "^1.1.0",
     "cldr-data": "^36.0.2",
     "clone": "^2.1.2",


### PR DESCRIPTION
## Résumé

Corrige la vulnérabilité **moderate** dans `body-parser@2.2.0` du package engine :
GHSA-wqch-xfxh-vrr4 (CWE-400, DoS via url encoding). La version `2.3.0` corrige.

Équivalent de la PR Dependabot #457 (fermée). Le `^2.2.0` permettait déjà 2.3.0 ;
le lockfile verrouillait 2.2.0 — mise à jour explicite à `^2.3.0`.

## Vérifications
- `npm audit` : plus de vulnérabilité `body-parser`
- Audits critiques : exit=0 (core, main, engine, timer, eval-service)
- Tests engine : 139/139