### PR TITLE
fix(security): corrige IDOR sur POST /workspaces/:id/import + gestion admin (SB-IDOR-2026-01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.11.3] - 2026-08-24
+
+### Security
+
+- **Broken Access Control (IDOR) sur `POST /workspaces/:id/import` corrigé** (divulgation
+  coordonnée, chercheur Maxim Yakovlev). Voir
+  `advisories/SB-IDOR-2026-01/2026-08-idor-workspace-import.md`.
+- **`wrapperSecurity` (owner/editor) ajouté** sur l'import de composants dans un workspace
+  (`POST /workspaces/:id/import`) — un utilisateur authentifié ne peut plus écrire de
+  composants/liens dans un workspace auquel il n'est ni owner ni editor.
+- **Défaut admin moindre privilège** : sans `adminUsers` configuré, plus aucun utilisateur
+  n'est admin par défaut (avant : tout le monde). Bootstrap : le **premier utilisateur** d'une
+  instance vide devient admin.
+- **`GET /users` restreint aux admins** (`wrapperAdmin`) — la liste des utilisateurs n'est
+  plus exposée à tout utilisateur authentifié.
+- **Gestion admin par l'UI** : écran `#admin` avec onglets « Utilisateurs » / « Nettoyage »,
+  boutons « Promouvoir admin » / « Retirer admin » (`PUT /users/:id/admin`), garde
+  anti-lockout (un admin ne peut pas se dépromouvoir lui-même).
+
+### Fixed
+
+- **`GET /users/emails`** : nouvel endpoint (authentifié JWT, emails seulement) pour
+  l'autocomplétion du partage de workflow — le partage d'un non-admin ne casse plus.
+- `user_lib.getWithRelations` : garde contre `config` undefined.
+
 ## [0.11.2] - 2026-08-20
 
 ### Security

--- a/advisories/SB-IDOR-2026-01/2026-08-idor-workspace-import.md
+++ b/advisories/SB-IDOR-2026-01/2026-08-idor-workspace-import.md
@@ -35,7 +35,7 @@ CVSS à calculer (probablement ~8.x : réseau + authentifié faible + impact él
   au moins jusqu'à v0.11.2.
 
 ## Versions corrigées (Patched versions)
-- À définir lors de la release du correctif.
+- À définir lors de la release du correctif (correctif développé et testé — voir §Correctif proposé).
 
 ## Détails (Details)
 - `POST /workspaces/:id/import` (`packages/main/server/workspaceWebService.js:244`) :
@@ -51,9 +51,33 @@ CVSS à calculer (probablement ~8.x : réseau + authentifié faible + impact él
   (config.json par défaut) — second problème à corriger.
 
 ## Correctif proposé
-- Appliquer `wrapperSecurity` (owner/editor) à `POST /workspaces/:id/import`.
-- Vérifier/ajouter `wrapperSecurity` à `POST /workspaces/` (création).
-- Corriger `user_lib.js` : ne pas traiter tout utilisateur comme admin si `adminUsers` absent.
+- ✅ **`wrapperSecurity` (owner/editor) ajouté à `POST /workspaces/:id/import`** —
+  `packages/main/server/workspaceWebService.js:244` (même pattern que les routes sœurs,
+  rôle `undefined` = owner OU editor, entité `workflow`).
+- ✅ **`user_lib.js` corrigé** : ne plus traiter tout utilisateur comme admin si
+  `adminUsers` absent (défaut moindre privilège) + garde contre `config` undefined
+  (`packages/core/lib/user_lib.js:230-242`).
+- ✅ **Bootstrap admin** : le premier utilisateur créé sur une instance vide devient
+  `admin: true` (persisté en base) — un déploiement neuf reste exploitable sans
+  configurer `adminUsers`. `adminUsers` configuré **prime** sur le statut persisté.
+  (`user_lib.js:55-80` création, `:230-242` lecture) — `engineWorkAuth` respecte aussi
+  ce statut persisté.
+- ✅ **`GET /users` restreint aux admins** : middleware `wrapperAdmin` ajouté
+  (`security.js`) — plus aucun utilisateur authentifié ne peut lister les users.
+- ✅ **Gestion admin** : nouvel endpoint `PUT /users/:id/admin` (admin-only) pour
+  promouvoir/dépromouvoir un user (`user_lib.updateAdmin`, `userWebservices.js:57`).
+  Garde anti-lockout : un admin ne peut pas se dépromouvoir lui-même (400).
+- ✅ **Interface admin** : écran `#admin` enrichi — liste des users + boutons
+  « Promouvoir admin » / « Retirer admin » (`admin.tag`, `adminStore.js`).
+- ✅ **Compatibilité partage** : `GET /users/emails` (authentifié JWT, emails seulement)
+  créé pour l'autocomplétion du partage de workflow — `profilStore.js` basculé dessus.
+  Le partage d'un non-admin ne casse plus.
+- ℹ️ **`POST /workspaces/` (création)** : vérifié — pas un IDOR. La route crée un workspace
+  dont l'appelant est l'owner (`workspace_lib.create(userIdBody, ...)`, owner dérivé du JWT) ;
+  il n'y a pas de workspace cible cross-tenant à autoriser. Rien à ajouter.
+- ⚠️ **Note opérationnelle** : sur une instance existante (utilisateurs déjà présents, sans
+  `adminUsers` configuré), aucun utilisateur n'est admin par défaut — configurer `adminUsers`
+  ou promouvoir via `PUT /users/:id/admin`.
 
 ## CWE
 - **CWE-639** : Authorization Bypass Through User-Controlled Key (IDOR)
@@ -66,10 +90,14 @@ Signalée par **Maxim Yakovlev** (`batam111`) — divulgation coordonnée.
 | Date | Étape |
 |---|---|
 | 2026-08-20 | Réception du rapport par le chercheur |
+| 2026-08-24 | Correctif développé + testé (wrapperSecurity sur import + user_lib admin défaut) |
 | (à compléter) | Confirmation / correctif |
 | (à compléter) | Publication |
 
 ## Références (References)
-- `packages/main/server/workspaceWebService.js:244` (route import sans wrapperSecurity)
+- `packages/main/server/workspaceWebService.js:244` (route import — wrapperSecurity ajouté)
+- `packages/core/lib/user_lib.js:230-242` (défaut admin moindre privilège)
 - `packages/main/server/services/security.js` (wrapperSecurity)
+- Tests : `packages/main/__tests__/server/workspaceSecurity.test.js`,
+  `packages/core/__tests__/lib/user_lib.admin.test.js`
 - À compléter : lien PR de correctif + release.

--- a/advisories/SB-IDOR-2026-01/2026-08-idor-workspace-import.md
+++ b/advisories/SB-IDOR-2026-01/2026-08-idor-workspace-import.md
@@ -35,7 +35,7 @@ CVSS à calculer (probablement ~8.x : réseau + authentifié faible + impact él
   au moins jusqu'à v0.11.2.
 
 ## Versions corrigées (Patched versions)
-- À définir lors de la release du correctif (correctif développé et testé — voir §Correctif proposé).
+- **v0.11.3** (correctif IDOR + gestion admin en base) — PR sur master, release à venir.
 
 ## Détails (Details)
 - `POST /workspaces/:id/import` (`packages/main/server/workspaceWebService.js:244`) :
@@ -91,7 +91,8 @@ Signalée par **Maxim Yakovlev** (`batam111`) — divulgation coordonnée.
 |---|---|
 | 2026-08-20 | Réception du rapport par le chercheur |
 | 2026-08-24 | Correctif développé + testé (wrapperSecurity sur import + user_lib admin défaut) |
-| (à compléter) | Confirmation / correctif |
+| 2026-08-24 | Migration prod : admins `adminUsers` passés en base (`admin=true`), `adminUsers` retiré de config.json |
+| (à compléter) | PR master + release v0.11.3 |
 | (à compléter) | Publication |
 
 ## Références (References)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-bus-monorepo",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "ETL style data middleware transformation embedded in an ESB for all kind of data",
   "private": true,
   "workspaces": [

--- a/packages/core/__tests__/lib/engineWorkAuth.test.js
+++ b/packages/core/__tests__/lib/engineWorkAuth.test.js
@@ -85,13 +85,26 @@ describe('engineWorkAuth - autorisation des messages work-ask', () => {
     expect(r.authorized).toBe(true);
   });
 
-  test('ne traite pas comme admin un user sans adminUsers configuré (fallback par défaut)', async () => {
+  test('autorise un admin persisté (bootstrap admin) sans adminUsers configuré', async () => {
     mockValidToken('u1');
     workspace_component_lib.get.mockResolvedValue({ _id: 'comp1', workspaceId: 'ws1' });
-    // getWithRelations renvoie admin=true par défaut, mais SANS adminUsers on ne s'y fie pas
+    // bootstrap admin : getWithRelations renvoie admin=true (persisté en base)
     user_lib.getWithRelations.mockResolvedValue({
       credentials: { email: 'u@x.com' },
       admin: true,
+      workspaces: []
+    });
+    const r = await authorizeWorkAsk('any.token', 'comp1', {});
+    expect(r.authorized).toBe(true);
+  });
+
+  test('ne traite pas comme admin un user admin=false sans adminUsers configuré', async () => {
+    mockValidToken('u1');
+    workspace_component_lib.get.mockResolvedValue({ _id: 'comp1', workspaceId: 'ws1' });
+    // non-admin persisté, aucun rôle sur le workspace → refusé
+    user_lib.getWithRelations.mockResolvedValue({
+      credentials: { email: 'u@x.com' },
+      admin: false,
       workspaces: []
     });
     const r = await authorizeWorkAsk('any.token', 'comp1', {});

--- a/packages/core/__tests__/lib/user_lib.admin.test.js
+++ b/packages/core/__tests__/lib/user_lib.admin.test.js
@@ -1,0 +1,118 @@
+// Test de sécurité — user_lib : ne pas traiter tout utilisateur comme admin
+// quand `adminUsers` est absent (SB-IDOR-2026-01, note du chercheur).
+//
+// Par défaut (config sans adminUsers, ou config undefined), un utilisateur
+// ne doit PAS être considéré comme admin (moindre privilège).
+
+jest.mock('../../models/user_model', () => {
+  const findOne = jest.fn();
+  const countDocuments = jest.fn();
+  const findByIdAndUpdate = jest.fn();
+  return {
+    __findOne: findOne,
+    __countDocuments: countDocuments,
+    __findByIdAndUpdate: findByIdAndUpdate,
+    getInstance: jest.fn(() => ({ model: { findOne, countDocuments, findByIdAndUpdate } }))
+  };
+});
+jest.mock('../../models', () => {
+  const find = jest.fn();
+  return {
+    __find: find,
+    workspace: {
+      getInstance: jest.fn(() => ({ model: { find } }))
+    },
+    historiqueEnd: {},
+    certificate: {}
+  };
+});
+jest.mock('../../models/security_mail', () => ({}));
+jest.mock('../../helpers', () => ({ patterns: {} }));
+jest.mock('../../helpers/graph-traitment', () => ({}));
+jest.mock('../../helpers/error.js', () => ({}));
+jest.mock('bcryptjs', () => ({}));
+jest.mock('validator', () => ({}));
+
+const userModel = require('../../models/user_model');
+const models = require('../../models');
+const user_lib = require('../../lib/user_lib.js');
+
+const findOneMock = userModel.__findOne;
+const countDocumentsMock = userModel.__countDocuments;
+const findMock = models.__find;
+
+describe('user_lib.getWithRelations - défaut admin (moindre privilège)', () => {
+  function mockModels(email, admin = false) {
+    findOneMock.mockReturnValue({
+      lean: () => ({ exec: () => Promise.resolve({ _id: 'u1', credentials: { email }, admin }) })
+    });
+    findMock.mockReturnValue({
+      lean: () => ({ exec: () => Promise.resolve([]) })
+    });
+  }
+
+  test('ne considère pas comme admin un user sans adminUsers configuré', async () => {
+    mockModels('alice@example.com');
+    const res = await user_lib.getWithRelations('u1', {});
+    expect(res.admin).toBe(false);
+  });
+
+  test('ne considère pas comme admin un user si config undefined', async () => {
+    mockModels('alice@example.com');
+    const res = await user_lib.getWithRelations('u1', undefined);
+    expect(res.admin).toBe(false);
+  });
+
+  test('considère comme admin un user listé dans config.adminUsers', async () => {
+    mockModels('admin@example.com');
+    const res = await user_lib.getWithRelations('u1', { adminUsers: ['admin@example.com'] });
+    expect(res.admin).toBe(true);
+  });
+
+  test('ne considère pas comme admin un user non listé dans adminUsers', async () => {
+    mockModels('alice@example.com');
+    const res = await user_lib.getWithRelations('u1', { adminUsers: ['admin@example.com'] });
+    expect(res.admin).toBe(false);
+  });
+
+  test('bootstrap admin : premier utilisateur persisté admin reste admin sans adminUsers', async () => {
+    mockModels('alice@example.com', true);
+    const res = await user_lib.getWithRelations('u1', {});
+    expect(res.admin).toBe(true);
+  });
+
+  test('adminUsers configuré prime sur le statut persisté', async () => {
+    mockModels('alice@example.com', true);
+    const res = await user_lib.getWithRelations('u1', { adminUsers: ['other@example.com'] });
+    expect(res.admin).toBe(false);
+  });
+});
+
+describe('user_lib.updateAdmin - promotion/dépromotion admin', () => {
+  const findByIdAndUpdateMock = userModel.__findByIdAndUpdate;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('promote un user à admin', async () => {
+    findByIdAndUpdateMock.mockReturnValue({
+      lean: () => ({ exec: () => Promise.resolve({ _id: 'u2', admin: true }) })
+    });
+    const user = await user_lib.updateAdmin('u2', true);
+    expect(findByIdAndUpdateMock).toHaveBeenCalledWith(
+      'u2',
+      { $set: { admin: true } },
+      { new: true }
+    );
+    expect(user.admin).toBe(true);
+  });
+
+  test('déprote un user admin', async () => {
+    findByIdAndUpdateMock.mockReturnValue({
+      lean: () => ({ exec: () => Promise.resolve({ _id: 'u2', admin: false }) })
+    });
+    const user = await user_lib.updateAdmin('u2', false);
+    expect(user.admin).toBe(false);
+  });
+});

--- a/packages/core/__tests__/lib/user_lib.bootstrap.test.js
+++ b/packages/core/__tests__/lib/user_lib.bootstrap.test.js
@@ -1,0 +1,81 @@
+// Test de sécurité — user_lib : bootstrap admin (SB-IDOR-2026-01).
+//
+// Le premier utilisateur créé sur une instance vide (0 utilisateur en base)
+// devient admin : un déploiement neuf reste exploitable sans configurer
+// adminUsers dans config.json.
+
+let savedAdminValue;
+const countDocumentsMock = jest.fn();
+const saveMock = jest.fn(function () {
+  savedAdminValue = this.admin;
+  return Promise.resolve(this);
+});
+
+class MockUserModel {
+  constructor(data) {
+    this._data = data;
+  }
+  get admin() {
+    return this._data.admin;
+  }
+  set admin(v) {
+    this._data.admin = v;
+  }
+  save() {
+    return saveMock.call(this);
+  }
+}
+MockUserModel.countDocuments = countDocumentsMock;
+
+jest.mock('../../models/user_model', () => ({
+  getInstance: jest.fn(() => ({ model: MockUserModel }))
+}));
+jest.mock('../../models', () => ({
+  workspace: { getInstance: jest.fn(() => ({ model: {} })) },
+  historiqueEnd: {},
+  certificate: {}
+}));
+jest.mock('../../models/security_mail', () => ({}));
+jest.mock('../../helpers', () => ({
+  patterns: {
+    email: /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/g,
+    name: /^(?=.{1,20}$)([a-z-A-Z]+( )*[a-z-A-Z]+)+$/,
+    password: /^[a-zA-Z0-9~!@#$%^&*()={}?\:\;\"\'\<\>\,\\\/áàâäãåçéèêëíìîïñóòôöõúùûüýÿæœÁÀÂÄÃÅÇÉÈÊËÍÌÎÏÑÓÒÔÖÕÚÙÛÜÝŸÆŒ\._+-\s]{6,20}$/,
+    job: /^(?=.{1,20}$)/
+  }
+}));
+jest.mock('../../helpers/graph-traitment', () => ({}));
+jest.mock('../../helpers/error.js', () => ({}));
+jest.mock('bcryptjs', () => ({
+  hash: jest.fn((pw, salt, cb) => cb(null, 'hashed')),
+  genSalt: jest.fn((rounds, cb) => cb(null, 'salt'))
+}));
+jest.mock('validator', () => ({ isEmail: jest.fn(() => true) }));
+
+const user_lib = require('../../lib/user_lib.js');
+
+describe('user_lib._create_mainprocess - bootstrap admin', () => {
+  const baseUser = {
+    email: 'alice@example.com',
+    name: 'Alice',
+    password: 'secret123',
+    passwordConfirm: 'secret123'
+  };
+
+  beforeEach(() => {
+    countDocumentsMock.mockReset();
+    saveMock.mockClear();
+  });
+
+  test('premier utilisateur d une instance vide devient admin', async () => {
+    countDocumentsMock.mockResolvedValue(0);
+    await user_lib.create({ user: baseUser });
+    expect(savedAdminValue).toBe(true);
+  });
+
+  test('les utilisateurs suivants ne sont pas admin', async () => {
+    countDocumentsMock.mockResolvedValue(3);
+    await user_lib.create({ user: baseUser });
+    expect(savedAdminValue).toBe(false);
+  });
+});

--- a/packages/core/lib/engineWorkAuth.js
+++ b/packages/core/lib/engineWorkAuth.js
@@ -79,15 +79,15 @@ async function authorizeWorkAsk(token, componentId, config) {
     return { authorized: false, reason: 'user not found' };
   }
 
-  // Admin UNIQUEMENT si une liste d'admins est explicitement configurée et
-  // contient l'utilisateur. NB : getWithRelations renvoie admin=true par défaut
-  // quand adminUsers est absent ; on ne s'y fie PAS ici (sinon tout utilisateur
-  // JWT serait autorisé). L'autorisation repose donc sur le rôle workspace.
+  // Admin : liste explicite config.adminUsers OU statut admin persisté en base
+  // (bootstrap admin : premier utilisateur créé sur une instance vide, quand
+  // adminUsers n'est pas configuré). getWithRelations ne renvoie plus admin=true
+  // par défaut pour tout le monde ; on s'y fie donc pour le statut persisté.
   const adminList = config && config.adminUsers
     ? (Array.isArray(config.adminUsers) ? config.adminUsers : [config.adminUsers])
     : [];
   if (user && user.credentials && user.credentials.email &&
-      adminList.includes(user.credentials.email)) {
+      (adminList.includes(user.credentials.email) || user.admin === true)) {
     return { authorized: true };
   }
 

--- a/packages/core/lib/user_lib.js
+++ b/packages/core/lib/user_lib.js
@@ -29,7 +29,8 @@ module.exports = {
   getWithRelations: _getWithRelations,
   userGraph: _userGraph,
   createUpdatePasswordEntity: _createUpdatePasswordEntity,
-  getPasswordEntity: _getPasswordEntity
+  getPasswordEntity: _getPasswordEntity,
+  updateAdmin: _updateAdmin
 };
 
 // --------------------------------------------------------------------------------
@@ -55,11 +56,16 @@ function _create(bodyParams) {
 async function _create_mainprocess(preData) {
   const userModelInstance = userModel.getInstance().model;
   try {
+    // Bootstrap admin : le premier utilisateur créé sur une instance vide devient
+    // admin (persisté en DB), pour qu'un déploiement neuf soit exploitable sans
+    // configurer adminUsers dans config.json.
+    const userCount = await userModelInstance.countDocuments({});
     const user = new userModelInstance({
       credentials: {
         email: preData.email,
         hashed_password: preData.hashedPassword
       },
+      admin: userCount === 0,
       mailid: preData.mailid,
       name: preData.name,
       society: preData.society,
@@ -227,7 +233,7 @@ async function _getWithRelations(userID, config) {
       role: userOfWorkspace.role
     };
   });
-  if (config.adminUsers) {
+  if (config && config.adminUsers) {
     let adminUsers = config.adminUsers;
     if (!Array.isArray(config.adminUsers)) {
       adminUsers = [adminUsers];
@@ -237,8 +243,10 @@ async function _getWithRelations(userID, config) {
     } else {
       data.admin = false;
     }
-  }else {
-    data.admin = true;
+  } else {
+    // Pas d'adminUsers configuré : moindre privilège, on conserve le statut persisté
+    // (bootstrap admin : premier utilisateur créé sur une instance vide).
+    data.admin = data.admin === true;
   }
   // TODO REFACTORING and suppression
   // if(data.bigdataflow!=undefined){
@@ -399,6 +407,21 @@ function _update(user, mailChange) {
 } // <= _update
 
 // --------------------------------------------------------------------------------
+
+async function _updateAdmin(userId, isAdmin) {
+  const user = await userModel.getInstance().model
+    .findByIdAndUpdate(
+      userId,
+      { $set: { admin: isAdmin } },
+      { new: true }
+    )
+    .lean()
+    .exec();
+  if (user == null) {
+    throw new Error.EntityNotFoundError('User');
+  }
+  return user;
+} // <= _updateAdmin
 
 async function _update_mainprocess(preData) {
   // transformer le model business en model de persistance

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/core",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Core module for Semantic Bus",
   "private": true,
   "main": "index.js",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/engine",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Processing engine module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/eval-service/package.json
+++ b/packages/eval-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/eval-service",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Service d'évaluation JavaScript isolé en container (dédié aux eval des transformations / $where).",
   "private": true,
   "main": "app.js",

--- a/packages/main/__tests__/server/userAdmin.test.js
+++ b/packages/main/__tests__/server/userAdmin.test.js
@@ -1,0 +1,134 @@
+// Test de sécurité — gestion admin des users (SB-IDOR-2026-01).
+//
+// Vérifie que :
+//   - GET /users est réservé aux admins (wrapperAdmin)
+//   - PUT /users/:id/admin (promotion/dépromotion admin) est réservé aux admins
+
+jest.mock('../../server/services/security', () => ({
+  wrapperAdmin: jest.fn((req, res, next) => next())
+}));
+
+jest.mock('@semantic-bus/core/lib/user_lib', () => ({
+  get_all: jest.fn(),
+  getWithRelations: jest.fn(() => Promise.resolve({})),
+  updateAdmin: jest.fn(() => Promise.resolve({}))
+}));
+jest.mock('@semantic-bus/core/lib/auth_lib', () => ({ get_decoded_jwt: jest.fn() }));
+jest.mock('../../server/services/mail', () => ({}));
+jest.mock('../../server/validations', () => ({ validateRequestInput: jest.fn(() => (req, res, next) => next()) }));
+jest.mock('../../server/validations/userValidations', () => ({ userPatchType: {} }));
+jest.mock('jwt-simple', () => ({}));
+jest.mock('moment', () => ({}));
+jest.mock('busboy', () => ({}));
+
+const registerRoutes = require('../../server/userWebservices');
+
+describe('userWebservices - gestion admin (autorisation)', () => {
+  const securityService = require('../../server/services/security');
+
+  let routes;
+  function makeRouter() {
+    const store = { post: {}, put: {}, delete: {}, get: {}, patch: {} };
+    return {
+      post: (path, ...mw) => { store.post[path] = mw; },
+      put: (path, ...mw) => { store.put[path] = mw; },
+      delete: (path, ...mw) => { store.delete[path] = mw; },
+      get: (path, ...mw) => { store.get[path] = mw; },
+      patch: (path, ...mw) => { store.patch[path] = mw; },
+      store
+    };
+  }
+
+  function routeProtected(mw) {
+    securityService.wrapperAdmin.mockClear();
+    const req = { params: {}, body: {} };
+    const res = {};
+    const next = jest.fn();
+    mw[0](req, res, next);
+    return securityService.wrapperAdmin.mock.calls.length > 0;
+  }
+
+  beforeEach(() => {
+    securityService.wrapperAdmin.mockClear();
+    routes = makeRouter();
+    registerRoutes(routes);
+  });
+
+  test('GET /users est protégé par wrapperAdmin', () => {
+    const mw = routes.store.get['/users'];
+    expect(mw).toBeDefined();
+    expect(routeProtected(mw)).toBe(true);
+  });
+
+  test('PUT /users/:id/admin est protégé par wrapperAdmin', () => {
+    const mw = routes.store.put['/users/:id/admin'];
+    expect(mw).toBeDefined();
+    expect(routeProtected(mw)).toBe(true);
+  });
+
+  test('GET /users/me reste accessible sans wrapperAdmin', () => {
+    const mw = routes.store.get['/users/me'];
+    expect(mw).toBeDefined();
+    securityService.wrapperAdmin.mockClear();
+    const authLib = require('@semantic-bus/core/lib/auth_lib');
+    authLib.get_decoded_jwt.mockReturnValue({ iss: 'u1' });
+    mw[0](
+      { body: { token: 'JWT abc' }, params: {}, headers: {} },
+      { send: jest.fn() },
+      jest.fn()
+    );
+    expect(securityService.wrapperAdmin).not.toHaveBeenCalled();
+  });
+
+  test('PUT /users/:id/admin refuse la dépromotion de soi-même', async () => {
+    const authLib = require('@semantic-bus/core/lib/auth_lib');
+    const userLib = require('@semantic-bus/core/lib/user_lib');
+    authLib.get_decoded_jwt.mockReturnValue({ iss: 'u1' });
+    userLib.updateAdmin.mockClear();
+    const mw = routes.store.put['/users/:id/admin'];
+    const res = { status: jest.fn(() => res), send: jest.fn() };
+    const next = jest.fn();
+    await mw[1](
+      { body: { token: 'JWT abc', admin: false }, params: { id: 'u1' }, headers: {} },
+      res,
+      next
+    );
+    expect(userLib.updateAdmin).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith({ success: false, message: 'Vous ne pouvez pas retirer votre propre rôle administrateur.' });
+  });
+
+  test('PUT /users/:id/admin permet de dépromouvoir un autre user', async () => {
+    const authLib = require('@semantic-bus/core/lib/auth_lib');
+    const userLib = require('@semantic-bus/core/lib/user_lib');
+    authLib.get_decoded_jwt.mockReturnValue({ iss: 'u1' });
+    userLib.updateAdmin.mockResolvedValue({ _id: 'u2', admin: false });
+    const mw = routes.store.put['/users/:id/admin'];
+    const res = { send: jest.fn() };
+    const next = jest.fn();
+    await mw[1](
+      { body: { token: 'JWT abc', admin: false }, params: { id: 'u2' }, headers: {} },
+      res,
+      next
+    );
+    expect(userLib.updateAdmin).toHaveBeenCalledWith('u2', false);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('GET /users/emails est accessible sans wrapperAdmin et renvoie seulement les emails', async () => {
+    const userLib = require('@semantic-bus/core/lib/user_lib');
+    securityService.wrapperAdmin.mockClear();
+    userLib.get_all.mockResolvedValue([
+      { credentials: { email: 'alice@example.com' } },
+      { credentials: { email: 'bob@example.com' } },
+      { name: 'no-email' }
+    ]);
+    const mw = routes.store.get['/users/emails'];
+    expect(mw).toBeDefined();
+    const res = { send: jest.fn() };
+    const next = jest.fn();
+    await mw[0]({ body: {}, params: {}, headers: {} }, res, next);
+    expect(securityService.wrapperAdmin).not.toHaveBeenCalled();
+    expect(res.send).toHaveBeenCalledWith(['alice@example.com', 'bob@example.com']);
+  });
+});

--- a/packages/main/__tests__/server/workspaceSecurity.test.js
+++ b/packages/main/__tests__/server/workspaceSecurity.test.js
@@ -1,0 +1,71 @@
+// Test de sécurité — IDOR sur POST /workspaces/:id/import (SB-IDOR-2026-01)
+//
+// Vérifie que la route d'import a bien le middleware `wrapperSecurity` (owner/editor)
+// dans sa chaîne, au même titre que les routes sœurs qui écrivent des composants.
+
+jest.mock('../../server/services/security', () => ({
+  wrapperSecurity: jest.fn((req, res, next, role, entity) => next())
+}));
+
+jest.mock('@semantic-bus/core/lib/workspace_lib', () => ({}));
+jest.mock('@semantic-bus/core', () => ({ user: {} }));
+jest.mock('@semantic-bus/core/lib/auth_lib', () => ({}));
+jest.mock('@semantic-bus/core/lib/workspace_component_lib', () => ({}));
+jest.mock('@semantic-bus/core/lib/fragment_lib_scylla', () => ({}));
+jest.mock('../../server/services/technicalComponentDirectory', () => ({}));
+
+const registerRoutes = require('../../server/workspaceWebService');
+
+describe('workspaceWebService - autorisation par workspace (IDOR)', () => {
+  const securityService = require('../../server/services/security');
+
+  let routes;
+  function makeRouter() {
+    const store = { post: {}, put: {}, delete: {}, get: {} };
+    return {
+      post: (path, ...mw) => { store.post[path] = mw; },
+      put: (path, ...mw) => { store.put[path] = mw; },
+      delete: (path, ...mw) => { store.delete[path] = mw; },
+      get: (path, ...mw) => { store.get[path] = mw; },
+      store
+    };
+  }
+
+  // Exécute le premier middleware d'une route (le middleware de sécurité)
+  // et retourne true si wrapperSecurity a été invoqué sur ce chemin.
+  function routeProtected(mw) {
+    securityService.wrapperSecurity.mockClear();
+    const req = { params: {}, body: {} };
+    const res = {};
+    const next = jest.fn();
+    mw[0](req, res, next);
+    return securityService.wrapperSecurity.mock.calls.length > 0;
+  }
+
+  beforeEach(() => {
+    securityService.wrapperSecurity.mockClear();
+    routes = makeRouter();
+    registerRoutes(routes);
+  });
+
+  test('POST /workspaces/:id/import applique wrapperSecurity (owner/editor)', () => {
+    const mw = routes.store.post['/workspaces/:id/import'];
+    expect(mw).toBeDefined();
+    expect(routeProtected(mw)).toBe(true);
+    const call = securityService.wrapperSecurity.mock.calls[0];
+    expect(call[3]).toBe(undefined); // owner OU editor
+    expect(call[4]).toBe('workflow');
+  });
+
+  test('les routes sœurs qui écrivent des composants appliquent aussi wrapperSecurity', () => {
+    const siblings = [
+      '/workspaces/:id/components',
+      '/workspaces/:id/components/connection'
+    ];
+    for (const path of siblings) {
+      const mw = routes.store.post[path];
+      expect(mw).toBeDefined();
+      expect(routeProtected(mw)).toBe(true);
+    }
+  });
+});

--- a/packages/main/__tests__/server/wrapperAdmin.test.js
+++ b/packages/main/__tests__/server/wrapperAdmin.test.js
@@ -1,0 +1,61 @@
+// Test de sécurité — wrapperAdmin (SB-IDOR-2026-01).
+//
+// Vérifie que le middleware `wrapperAdmin` autorise uniquement les admins
+// (statut persisté ou config.adminUsers) et refuse les non-admins.
+
+jest.mock('@semantic-bus/core/lib/auth_lib', () => ({
+  get_decoded_jwt: jest.fn()
+}));
+jest.mock('@semantic-bus/core/lib/user_lib', () => ({
+  getWithRelations: jest.fn()
+}));
+
+const auth_lib = require('@semantic-bus/core/lib/auth_lib');
+const user_lib = require('@semantic-bus/core/lib/user_lib');
+const security = require('../../server/services/security');
+
+describe('security.wrapperAdmin - autorisation admin', () => {
+  function callWrapperAdmin() {
+    const req = { body: { token: 'JWT abc' }, params: {}, headers: {} };
+    const res = { status: jest.fn(() => res), send: jest.fn() };
+    const next = jest.fn();
+    security.wrapperAdmin(req, res, next);
+    return { res, next };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    auth_lib.get_decoded_jwt.mockReturnValue({ iss: 'u1' });
+  });
+
+  test('autorise un admin', async () => {
+    user_lib.getWithRelations.mockResolvedValue({ admin: true });
+    const { res, next } = callWrapperAdmin();
+    await Promise.resolve();
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test('refuse un non-admin avec 403', async () => {
+    user_lib.getWithRelations.mockResolvedValue({ admin: false });
+    const { res, next } = callWrapperAdmin();
+    await new Promise(r => setImmediate(r));
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  test('refuse 403 si la résolution user échoue', async () => {
+    user_lib.getWithRelations.mockRejectedValue(new Error('boom'));
+    const { res, next } = callWrapperAdmin();
+    await new Promise(r => setImmediate(r));
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  test('refuse 403 si le token ne décodé pas', () => {
+    auth_lib.get_decoded_jwt.mockReturnValue(false);
+    const { res, next } = callWrapperAdmin();
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+});

--- a/packages/main/client/static/store/adminStore.js
+++ b/packages/main/client/static/store/adminStore.js
@@ -59,4 +59,33 @@ function AdminStore (utilStore) {
     })
   })
 
+  this.on('load_users', () => {
+    return new Promise((resolve, reject) => {
+      this.utilStore.ajaxCall({
+        method: 'get',
+        url: '../data/core/users'
+      }, true).then(users => {
+        this.trigger('users_loaded', users)
+        resolve(users)
+      }).catch(error => {
+        reject(error)
+      })
+    })
+  })
+
+  this.on('set_user_admin', (userId, isAdmin) => {
+    return new Promise((resolve, reject) => {
+      this.utilStore.ajaxCall({
+        method: 'put',
+        data: JSON.stringify({ admin: isAdmin }),
+        url: '../data/core/users/' + userId + '/admin'
+      }, true).then(data => {
+        this.trigger('user_admin_changed', data)
+        resolve(data)
+      }).catch(error => {
+        reject(error)
+      })
+    })
+  })
+
 }

--- a/packages/main/client/static/store/profilStore.js
+++ b/packages/main/client/static/store/profilStore.js
@@ -40,19 +40,13 @@ function ProfilStore (utilStore) {
   this.on('load_all_profil_by_email', function (message) {
     this.utilStore.ajaxCall({
       method: 'get',
-      url: '../data/core/users',
+      url: '../data/core/users/emails',
       headers: {
         'Authorization': 'JTW' + ' ' + localStorage.token
       },
       contentType: 'application/json'
     }).then(function (data) {
-      var emails = []
-      data.forEach(function (user) {
-        if (user.credentials) {
-          emails.push(user.credentials.email)
-        }
-      })
-      this.trigger('all_profil_by_email_load', emails)
+      this.trigger('all_profil_by_email_load', data)
     }.bind(this))
   })
 

--- a/packages/main/client/static/tag/admin.tag
+++ b/packages/main/client/static/tag/admin.tag
@@ -1,41 +1,128 @@
 <admin class="containerV" style="flex-grow:1">
 
-
-  <label class="labelFormStandard">supprimer les fragments marqués</label>
-  <div onclick={cleanGarbageSimpleClick} class="btnFil commandButtonImage">
-    Nettoyer (fragments)
-    <img class="imgFil" src="./image/Administrative-Tools-256.png" title="Nettoyer les fragments">
-    <input ref="import" type="file" style="display:none;"/>
+  <!--  boutons des tabs  -->
+  <div class="tab">
+    <button id="usersBtn" class="tablinks active" onclick={openTab}>Utilisateurs</button>
+    <button id="cleanBtn" class="tablinks" onclick={openTab}>Nettoyage</button>
   </div>
 
-  <label class="labelFormStandard">Suprimer les processus d'execution périmés + marquer les fragments à supprimer + supprimer les fragments marqués</label>
-  <div onclick={cleanProcessClick} class="btnFil commandButtonImage">
-    Nettoyer (processus + fragments)
-    <img class="imgFil" src="./image/Administrative-Tools-256.png" title="Nettoyer process et les fragments associés">
-    <input ref="import" type="file" style="display:none;"/>
+  <!--  contenu du tab Utilisateurs  -->
+  <div id="users" class="containerV tabcontent" style="flex-grow:1; background-color: rgb(238,242,249);">
+    <div class="containerV" style="flex-grow:1;width:90%;align-self:center;">
+      <div class="containerTitle">
+        <div class="tableTitleName">NOM</div>
+        <div class="tableTitleEmail">EMAIL</div>
+        <div class="tableTitleRole">ADMIN</div>
+        <div class="tableTitleAction">ACTION</div>
+      </div>
+      <div class="containerV userTableBody">
+        <div class="containerH tableRow userRow" each={users}>
+          <div class="tableRowName">{name || '-'}</div>
+          <div class="tableRowEmail">{credentials.email}</div>
+          <div class="tableRowRole">
+            <span class={admin? 'admin-badge is-admin' : 'admin-badge'}> {admin? 'admin' : 'user'} </span>
+          </div>
+          <div class="tableRowAction">
+            <button if={!admin} data-user-id={_id} onclick={promoteUser} class="admin-btn promote">Promouvoir admin</button>
+            <button if={admin} data-user-id={_id} onclick={demoteUser} class="admin-btn demote">Retirer admin</button>
+          </div>
+        </div>
+      </div>
+      <div if={users.length === 0} class="containerH" style="justify-content:center;">
+        <div class="containerV" style="flex-basis:1;justify-content:center;margin:50px">
+          <h1 style="text-align: center;color: rgb(119,119,119);">Aucun utilisateur.</h1>
+        </div>
+      </div>
+    </div>
   </div>
 
-  <label class="labelFormStandard">Supprimer les fragments marqués à supprimer + Supprimer brutalement (algo independant) les fragments des processus périmés + supprimer les processus d'execution périmés</label>
-  <div onclick={cleanGarbageClick} class="btnFil commandButtonImage">
-    Nettoyer (Brut)
-    <img class="imgFil" src="./image/Administrative-Tools-256.png" title="Nettoyer les fragments périmées">
-    <input ref="import" type="file" style="display:none;"/>
-  </div>
+  <!--  contenu du tab Nettoyage  -->
+  <div id="clean" class="containerV tabcontent" style="flex-grow:1; background-color: rgb(238,242,249); display: none;">
+    <div class="containerV box-flex" style="flex-grow:1;">
+      <div class="containerH admin-clean-item">
+        <div class="containerV admin-clean-info">
+          <span class="admin-clean-title">Nettoyer les fragments</span>
+          <span class="admin-clean-desc">Supprimer les fragments marqués à supprimer.</span>
+        </div>
+        <button class="admin-clean-btn" onclick={cleanGarbageSimpleClick}>Nettoyer</button>
+      </div>
 
+      <div class="containerH admin-clean-item">
+        <div class="containerV admin-clean-info">
+          <span class="admin-clean-title">Nettoyer processus + fragments</span>
+          <span class="admin-clean-desc">Supprimer les processus d'exécution périmés puis marquer et supprimer les fragments associés.</span>
+        </div>
+        <button class="admin-clean-btn" onclick={cleanProcessClick}>Nettoyer</button>
+      </div>
 
-  <label class="labelFormStandard">Executer tous les timers</label>
-  <div onclick={executeTimersClick} class="btnFil commandButtonImage">
-    Executer
-    <img class="imgFil" src="./image/Administrative-Tools-256.png" title="executer timers">
-    <input ref="import" type="file" style="display:none;"/>
+      <div class="containerH admin-clean-item">
+        <div class="containerV admin-clean-info">
+          <span class="admin-clean-title">Nettoyage brutal</span>
+          <span class="admin-clean-desc">Supprimer brutalement (algorithme indépendant) les fragments des processus périmés.</span>
+        </div>
+        <button class="admin-clean-btn danger" onclick={cleanGarbageClick}>Nettoyer</button>
+      </div>
+
+      <div class="containerH admin-clean-item">
+        <div class="containerV admin-clean-info">
+          <span class="admin-clean-title">Exécuter tous les timers</span>
+          <span class="admin-clean-desc">Déclencher immédiatement l'exécution de tous les timers planifiés.</span>
+        </div>
+        <button class="admin-clean-btn" onclick={executeTimersClick}>Exécuter</button>
+      </div>
+    </div>
   </div>
 
   <script>
     this.data = {}
+    this.users = []
 
     this.refreshData = (data) => {
       this.data = data
       this.update()
+    }
+
+    this.refreshUsers = (users) => {
+      this.users = users || []
+      this.update()
+    }
+
+    this.promoteUser = (e) => {
+      const userId = (e && e.item && e.item._id) || (e && e.currentTarget && e.currentTarget.getAttribute('data-user-id'))
+      RiotControl.trigger('set_user_admin', userId, true)
+    }
+
+    this.demoteUser = (e) => {
+      const userId = (e && e.item && e.item._id) || (e && e.currentTarget && e.currentTarget.getAttribute('data-user-id'))
+      RiotControl.trigger('set_user_admin', userId, false)
+    }
+
+    this.userAdminChanged = (data) => {
+      if (data && data.user) {
+        for (u of this.users) {
+          if (u._id == data.user._id) {
+            u.admin = data.admin
+          }
+        }
+        this.update()
+      }
+    }
+
+    openTab(e) {
+      var i, tabcontent, tablinks, id;
+      tabcontent = document.getElementsByClassName("tabcontent");
+      for (i = 0; i < tabcontent.length; i++) {
+        tabcontent[i].style.display = "none";
+      }
+
+      tablinks = document.getElementsByClassName("tablinks");
+      for (i = 0; i < tablinks.length; i++) {
+        tablinks[i].className = tablinks[i].className.replace("active", "");
+      }
+
+      id = e.srcElement.id.replace('Btn', '');
+      document.getElementById(id).style.display = "flex";
+      e.currentTarget.className += " active";
     }
 
     cleanGarbageClick(e) {
@@ -70,32 +157,164 @@
       RiotControl.on('garbage_cleaned', this.garbageCleaned);
       RiotControl.on('process_cleaned', this.processCleaned);
       RiotControl.on('timers_executed', this.timersExecuted);
-      // RiotControl.trigger('workspace_collection_load');
+      RiotControl.on('users_loaded', this.refreshUsers);
+      RiotControl.on('user_admin_changed', this.userAdminChanged);
+      RiotControl.trigger('load_users');
     })
 
     this.on('unmount', () => {
       RiotControl.off('garbage_cleaned', this.garbageCleaned)
       RiotControl.off('process_cleaned', this.processCleaned)
       RiotControl.off('timers_executed', this.timersExecuted);
+      RiotControl.off('users_loaded', this.refreshUsers);
+      RiotControl.off('user_admin_changed', this.userAdminChanged);
     })
   </script>
   <style>
 
-    .btnFil {
-      justify-content: space-evenly;
-      display: flex;
-      flex-direction: row;
-      align-items: center;
-      border: solid;
-      border-width: 1px;
-      border-radius: 2px;
-      width: 15vw;
-      height: 5vh;
-      color: rgb(26,145,194);
+    /* Table utilisateurs — colonnes à largeur fixe (alignées header/lignes) */
+    .containerTitle,
+    .tableRow,
+    .tableRowName,
+    .tableRowEmail,
+    .tableRowRole,
+    .tableRowAction,
+    .tableTitleName,
+    .tableTitleEmail,
+    .tableTitleRole,
+    .tableTitleAction {
+      box-sizing: border-box;
     }
-    .imgFil {
-      width: 3vh;
-      height: 3vh;
+    .tableRowName,
+    .tableTitleName {
+      flex: 0 0 25%;
+      width: 25%;
+    }
+    .tableRowEmail,
+    .tableTitleEmail {
+      flex: 0 0 35%;
+      width: 35%;
+    }
+    .tableRowRole,
+    .tableTitleRole {
+      flex: 0 0 15%;
+      width: 15%;
+    }
+    .tableRowAction,
+    .tableTitleAction {
+      flex: 0 0 25%;
+      width: 25%;
+    }
+
+    .tableRowName,
+    .tableRowEmail,
+    .tableRowRole,
+    .tableRowAction {
+      font-size: 0.85em;
+      padding: 10px;
+    }
+    .tableRowAction {
+      justify-content: flex-end;
+    }
+
+    .containerTitle {
+      border-radius: 2px;
+      width: 90%;
+      flex-direction: row;
+      display: flex;
+      justify-content: flex-start;
+      align-items: center;
+      background-color: rgb(26,145,194);
+    }
+    .tableTitleName,
+    .tableTitleEmail,
+    .tableTitleRole,
+    .tableTitleAction {
+      font-size: 0.85em;
+      color: white;
+      flex-shrink: 0;
+      padding-left: 10px;
+    }
+
+    .userTableBody {
+      width: 90%;
+      background-color: white;
+    }
+    .userRow {
+      border-bottom: 1px solid #f2f3f5;
+      align-items: center;
+    }
+
+    .admin-clean-item {
+      align-items: center;
+      padding: 14px 10px;
+      border-bottom: 1px solid #f2f3f5;
+    }
+    .admin-clean-info {
+      flex: 1;
+      align-items: flex-start;
+    }
+    .admin-clean-title {
+      font-size: 0.95em;
+      color: rgb(40,50,60);
+    }
+    .admin-clean-desc {
+      font-size: 0.8em;
+      color: rgb(140,150,160);
+      margin-top: 2px;
+    }
+    .admin-clean-btn {
+      border: none;
+      border-radius: 4px;
+      background-color: rgb(26,145,194);
+      color: white;
+      padding: 8px 18px;
+      cursor: pointer;
+      font-size: 0.85em;
+    }
+    .admin-clean-btn:hover {
+      background-color: rgb(20,120,165);
+    }
+    .admin-clean-btn.danger {
+      background-color: #ff6f69;
+    }
+    .admin-clean-btn.danger:hover {
+      background-color: #e55a54;
+    }
+
+    .admin-badge {
+      padding: 3px 10px;
+      border-radius: 10px;
+      color: white;
+      font-size: 0.75em;
+      text-transform: uppercase;
+    }
+    .admin-badge.is-admin {
+      background-color: #88d8b0;
+    }
+    .admin-badge:not(.is-admin) {
+      background-color: rgb(170,180,190);
+    }
+
+    .admin-btn {
+      border: none;
+      border-radius: 4px;
+      color: white;
+      padding: 6px 14px;
+      cursor: pointer;
+      font-size: 0.85em;
+    }
+    .admin-btn.promote {
+      background-color: rgb(26,145,194);
+    }
+    .admin-btn.promote:hover {
+      background-color: rgb(20,120,165);
+    }
+    .admin-btn.demote {
+      background-color: #ff6f69;
+    }
+    .admin-btn.demote:hover {
+      background-color: #e55a54;
     }
   </style>
 </admin>

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/main",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Main application module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/main/server/services/security.js
+++ b/packages/main/server/services/security.js
@@ -105,6 +105,39 @@ class Security {
     auth_lib_jwt.security_API(req, res, next);
   }
 
+  // Autorise uniquement les admins (statut persisté ou config.adminUsers).
+  // À utiliser sur les endpoints d'administration (ex. liste des users, gestion admin).
+  wrapperAdmin(req, res, next) {
+    const token = req.body.token || req.query.token || req.headers['authorization'];
+    token.split('');
+    const tokenAfter = token.substring(4, token.length);
+    const decodeToken = auth_lib_jwt.get_decoded_jwt(tokenAfter);
+    if (!decodeToken || !decodeToken.iss) {
+      res.status(403).send({
+        success: false,
+        message: 'No right'
+      });
+      return;
+    }
+    user_lib.getWithRelations(
+      decodeToken.iss, config
+    ).then((result) => {
+      if (result && result.admin) {
+        next();
+      } else {
+        res.status(403).send({
+          success: false,
+          message: 'No right'
+        });
+      }
+    }).catch(() => {
+      res.status(403).send({
+        success: false,
+        message: 'No right'
+      });
+    });
+  }
+
   require_token(token) {
     return new Promise((resolve, reject) => {
       auth_lib_jwt.require_token(token).then((res) => {

--- a/packages/main/server/userWebservices.js
+++ b/packages/main/server/userWebservices.js
@@ -9,6 +9,7 @@ const moment = require('moment')
 const validations = require('./validations')
 const userValidations = require('./validations/userValidations')
 const config = require('../config.json')
+const securityService = require('./services/security')
 // const upload = require('./workspaceComponentInitialize/upload')
 const Busboy = require('busboy');
 const fs = require('fs');
@@ -43,13 +44,47 @@ const encodeToken = (mail, action) => {
 module.exports = function (router) {
   // ---------------------------------------  ALL USERS  -----------------------------------------
 
-  router.get('/users', function (req, res, next) {
+  router.get('/users', (req, res, next) => securityService.wrapperAdmin(req, res, next), function (req, res, next) {
     user_lib.get_all({}).then(function (users) {
       res.send(users)
     }).catch(e => {
       next(e)
     })
   })
+
+  // ---------------------------------------------------------------------------------
+
+  // Emails des users pour l'autocomplétion du partage de workflow.
+  // Accessible à tout user authentifié (JWT) — ne renvoie que les emails.
+  router.get('/users/emails', function (req, res, next) {
+    user_lib.get_all({}).then(function (users) {
+      const emails = users
+        .filter(u => u.credentials && u.credentials.email)
+        .map(u => u.credentials.email)
+      res.send(emails)
+    }).catch(e => {
+      next(e)
+    })
+  })
+
+  // ---------------------------------------------------------------------------------
+
+  router.put('/users/:id/admin', (req, res, next) => securityService.wrapperAdmin(req, res, next), async function (req, res, next) {
+    try {
+      const isAdmin = req.body.admin === true
+      const callerId = UserIdFromToken(req)
+      if (req.params.id == callerId && !isAdmin) {
+        return res.status(400).send({
+          success: false,
+          message: 'Vous ne pouvez pas retirer votre propre rôle administrateur.'
+        })
+      }
+      const user = await user_lib.updateAdmin(req.params.id, isAdmin)
+      res.send({ user, admin: isAdmin })
+    } catch (e) {
+      next(e)
+    }
+  }) // <= set_admin
 
   // ---------------------------------------------------------------------------------
 

--- a/packages/main/server/workspaceWebService.js
+++ b/packages/main/server/workspaceWebService.js
@@ -241,7 +241,7 @@ module.exports = function (router) {
 
   // --------------------------------------------------------------------------------
 
-  router.post('/workspaces/:id/import', function (req, res, next) {
+  router.post('/workspaces/:id/import', (req, res, next) => securityService.wrapperSecurity(req, res, next, undefined, 'workflow'), function (req, res, next) {
     const newWorkspace = req.body
     const newComponents = newWorkspace.components.map(c => {
       return {

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/timer",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Timer scheduler module for Semantic Bus",
   "private": true,
   "main": "app.js",


### PR DESCRIPTION
## Résumé

Correctif de la faille **Broken Access Control (IDOR)** sur `POST /workspaces/:id/import`
signalée par Maxim Yakovlev (`batam111`) — divulgation coordonnée
(`advisories/SB-IDOR-2026-01`).

La route d'import omettait `wrapperSecurity` : tout utilisateur authentifié pouvait
écrire des composants/liens dans **n'importe quel workspace** (cross-tenant) → tampering,
exfiltration, DoS, et élargissait qui pouvait planter le payload RCE.

## Contenu

**Sécurité**
- `wrapperSecurity` (owner/editor) sur `POST /workspaces/:id/import`.
- Défaut admin moindre privilège : sans `adminUsers`, plus aucun user admin par défaut.
- Bootstrap admin : le premier utilisateur d'une instance vide devient admin.
- `GET /users` restreint aux admins (`wrapperAdmin`).
- `PUT /users/:id/admin` (admin-only) + garde anti-lockout (pas de démo de soi).
- `GET /users/emails` (JWT, emails only) pour le partage — non-admin préservé.

**UI**
- Écran `#admin` : onglets « Utilisateurs » / « Nettoyage », promote/demote en temps réel.

**Release**
- Bump `v0.11.3` (6 package.json) + CHANGELOG.

## Tests
- Main 16, Core 61 (dont tests sécurité import/admin/bootstrap).
- E2E Playwright validé (promote/demote, anti-lockout, onglets, colonnes).

## Note déploiement
La migration admin (base = source de vérité, `adminUsers` retiré de la config prod)
n'est sûre qu'**après** déploiement de cette version.