### PR TITLE
feat(admin): statistiques utilisateurs + tri + fix bandeau d'onglets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.11.4] - 2026-08-24
+
+### Added
+
+- **Statistiques users dans l'écran admin** (`#admin` → Utilisateurs) : nombre de
+  workflows, date d'inscription, dernière connexion, dernière exécution de workflow.
+- **Tri par colonnes** dans le tableau des utilisateurs (nom, email, admin, workflows,
+  inscription, dernière connexion, dernière exécution) — clic sur l'en-tête (▲/▼).
+- **`lastLogin`** : nouveau champ user, renseigné à chaque connexion (classique + Google).
+
+### Fixed
+
+- **Bandeau d'onglets de l'admin** : hauteur fixe (48px) — plus de compression/illisibilité
+  quand la liste des utilisateurs est longue ; la liste scrolle désormais.
+
 ## [0.11.3] - 2026-08-24
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-bus-monorepo",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "ETL style data middleware transformation embedded in an ESB for all kind of data",
   "private": true,
   "workspaces": [

--- a/packages/core/__tests__/lib/user_lib.admin.test.js
+++ b/packages/core/__tests__/lib/user_lib.admin.test.js
@@ -8,19 +8,28 @@ jest.mock('../../models/user_model', () => {
   const findOne = jest.fn();
   const countDocuments = jest.fn();
   const findByIdAndUpdate = jest.fn();
+  const find = jest.fn();
   return {
     __findOne: findOne,
     __countDocuments: countDocuments,
     __findByIdAndUpdate: findByIdAndUpdate,
-    getInstance: jest.fn(() => ({ model: { findOne, countDocuments, findByIdAndUpdate } }))
+    __find: find,
+    getInstance: jest.fn(() => ({ model: { findOne, countDocuments, findByIdAndUpdate, find } }))
   };
 });
 jest.mock('../../models', () => {
   const find = jest.fn();
+  const workspaceAggregate = jest.fn();
+  const processAggregate = jest.fn();
   return {
     __find: find,
+    __workspaceAggregate: workspaceAggregate,
+    __processAggregate: processAggregate,
     workspace: {
-      getInstance: jest.fn(() => ({ model: { find } }))
+      getInstance: jest.fn(() => ({ model: { find, aggregate: () => ({ exec: workspaceAggregate }) } }))
+    },
+    process: {
+      getInstance: jest.fn(() => ({ model: { aggregate: () => ({ exec: processAggregate }) } }))
     },
     historiqueEnd: {},
     certificate: {}
@@ -40,6 +49,8 @@ const user_lib = require('../../lib/user_lib.js');
 const findOneMock = userModel.__findOne;
 const countDocumentsMock = userModel.__countDocuments;
 const findMock = models.__find;
+const workspaceAggregateMock = models.__workspaceAggregate;
+const processAggregateMock = models.__processAggregate;
 
 describe('user_lib.getWithRelations - défaut admin (moindre privilège)', () => {
   function mockModels(email, admin = false) {
@@ -114,5 +125,58 @@ describe('user_lib.updateAdmin - promotion/dépromotion admin', () => {
     });
     const user = await user_lib.updateAdmin('u2', false);
     expect(user.admin).toBe(false);
+  });
+});
+
+describe('user_lib.getAdminUsersStats - stats admin (workflows, dates)', () => {
+  const userFindMock = userModel.__find;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function mockStatsData() {
+    userFindMock.mockReturnValue({
+      select: () => ({
+        lean: () => ({
+          exec: () => Promise.resolve([
+            { _id: 'u1', name: 'Alice', credentials: { email: 'alice@example.com' }, admin: true, dates: { created_at: new Date('2026-01-01') }, lastLogin: new Date('2026-08-01') }
+          ])
+        })
+      })
+    });
+    workspaceAggregateMock.mockResolvedValue([{ _id: 'alice@example.com', count: 3 }]);
+    processAggregateMock.mockResolvedValue([{ _id: 'u1', lastExecution: new Date('2026-08-20') }]);
+  }
+
+  test('retourne les stats agrégées par user', async () => {
+    mockStatsData();
+    const res = await user_lib.getAdminUsersStats();
+    expect(res).toHaveLength(1);
+    const u = res[0];
+    expect(u.email).toBe('alice@example.com');
+    expect(u.admin).toBe(true);
+    expect(u.workspaceCount).toBe(3);
+    expect(u.createdAt).toEqual(new Date('2026-01-01'));
+    expect(u.lastLogin).toEqual(new Date('2026-08-01'));
+    expect(u.lastExecution).toEqual(new Date('2026-08-20'));
+  });
+
+  test('retourne 0 workflow et dates null si absents', async () => {
+    userFindMock.mockReturnValue({
+      select: () => ({
+        lean: () => ({
+          exec: () => Promise.resolve([
+            { _id: 'u2', name: 'Bob', credentials: { email: 'bob@example.com' }, admin: false, dates: {}, lastLogin: null }
+          ])
+        })
+      })
+    });
+    workspaceAggregateMock.mockResolvedValue([]);
+    processAggregateMock.mockResolvedValue([]);
+    const res = await user_lib.getAdminUsersStats();
+    expect(res[0].workspaceCount).toBe(0);
+    expect(res[0].createdAt).toBe(null);
+    expect(res[0].lastExecution).toBe(null);
   });
 });

--- a/packages/core/lib/auth_lib.js
+++ b/packages/core/lib/auth_lib.js
@@ -50,6 +50,12 @@ class AuthLib {
     // Authenticate user (verify email and password)
     const userData = await this._authenticateUser(bodyParams.authentication);
 
+    // Enregistrer la date de dernière connexion (utilisée dans l'admin user list)
+    await userModel.getInstance().model
+      .findByIdAndUpdate(userData._id, { $set: { lastLogin: new Date() } })
+      .lean()
+      .exec();
+
     // Generate authentication token
     return await this._create_mainprocess(userData, bodyParams.authentication);
   }
@@ -184,6 +190,7 @@ class AuthLib {
           .then(async user => {
             user.googleToken = null;
             user.active = true;
+            user.lastLogin = new Date();
             const user_update = userModel.getInstance().model.findByIdAndUpdate(user._id, user).lean().exec();
             const payload = {
               exp: moment().add(14, 'days').unix(),

--- a/packages/core/lib/user_lib.js
+++ b/packages/core/lib/user_lib.js
@@ -7,6 +7,7 @@ const graphTraitement = require('../helpers/graph-traitment');
 const historiqueModel = require('../models').historiqueEnd;
 const SecureMailModel = require('../models/security_mail');
 const workspaceModel = require('../models').workspace;
+const processModel = require('../models').process;
 const certificateModel = require('../models').certificate;
 // let bigdataflowModel = require("../models").bigdataflow;
 const Error = require('../helpers/error.js');
@@ -27,6 +28,7 @@ module.exports = {
   update: _update,
   updateProfil,
   getWithRelations: _getWithRelations,
+  getAdminUsersStats: _getAdminUsersStats,
   userGraph: _userGraph,
   createUpdatePasswordEntity: _createUpdatePasswordEntity,
   getPasswordEntity: _getPasswordEntity,
@@ -285,6 +287,44 @@ async function _getWithRelations(userID, config) {
 
   //   });
 } // <= _getWithWorkspace
+
+// Statistiques admin sur les users : nb de workflows, date d'inscription, dernière
+// connexion, dernière exécution de workflow. Utilisée par la route admin GET /users.
+// Le nb de workflows et la dernière exécution sont calculés par aggregation groupée
+// (une requête par source, pas une par user).
+async function _getAdminUsersStats() {
+  const [users, workspaceCounts, lastProcesses] = await Promise.all([
+    userModel.getInstance().model
+      .find({})
+      .select('name credentials.email admin dates.created_at lastLogin')
+      .lean()
+      .exec(),
+
+    workspaceModel.getInstance().model.aggregate([
+      { $unwind: '$users' },
+      { $group: { _id: '$users.email', count: { $sum: 1 } } }
+    ]).exec(),
+
+    processModel.getInstance().model.aggregate([
+      { $sort: { timeStamp: -1 } },
+      { $group: { _id: '$ownerId', lastExecution: { $first: '$timeStamp' } } }
+    ]).exec()
+  ]);
+
+  const wsMap = new Map(workspaceCounts.map(w => [w._id, w.count]));
+  const procMap = new Map(lastProcesses.map(p => [p._id.toString(), p.lastExecution]));
+
+  return users.map(u => ({
+    _id: u._id,
+    name: u.name,
+    email: u.credentials.email,
+    admin: u.admin === true,
+    workspaceCount: wsMap.get(u.credentials.email) || 0,
+    createdAt: (u.dates && u.dates.created_at) || null,
+    lastLogin: u.lastLogin || null,
+    lastExecution: procMap.get(u._id.toString()) || null
+  }));
+} // <= _getAdminUsersStats
 
 function _userGraph(userId) {
   return new Promise(resolve => {

--- a/packages/core/model_schemas/user_schema.js
+++ b/packages/core/model_schemas/user_schema.js
@@ -76,6 +76,10 @@ const UserSchema = mongoose.Schema({
     created_at: Date,
     updated_at: Date
   },
+  lastLogin: {
+    type: Date,
+    default: null
+  },
   googleToken: {
     type: String,
     default: null

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/core",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Core module for Semantic Bus",
   "private": true,
   "main": "index.js",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/engine",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Processing engine module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/eval-service/package.json
+++ b/packages/eval-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/eval-service",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Service d'évaluation JavaScript isolé en container (dédié aux eval des transformations / $where).",
   "private": true,
   "main": "app.js",

--- a/packages/main/client/static/tag/admin.tag
+++ b/packages/main/client/static/tag/admin.tag
@@ -8,27 +8,35 @@
 
   <!--  contenu du tab Utilisateurs  -->
   <div id="users" class="containerV tabcontent" style="flex-grow:1; background-color: rgb(238,242,249);">
-    <div class="containerV" style="flex-grow:1;width:90%;align-self:center;">
+    <div class="containerV" style="flex-grow:1;width:95%;align-self:center;">
       <div class="containerTitle">
-        <div class="tableTitleName">NOM</div>
-        <div class="tableTitleEmail">EMAIL</div>
-        <div class="tableTitleRole">ADMIN</div>
+        <div class="tableTitleName sortable" data-sort="name" onclick={sortBy}>NOM {sortArrow('name')}</div>
+        <div class="tableTitleEmail sortable" data-sort="email" onclick={sortBy}>EMAIL {sortArrow('email')}</div>
+        <div class="tableTitleRole sortable" data-sort="admin" onclick={sortBy}>ADMIN {sortArrow('admin')}</div>
+        <div class="tableTitleCount sortable" data-sort="workspaceCount" onclick={sortBy}>WORKFLOWS {sortArrow('workspaceCount')}</div>
+        <div class="tableTitleDate sortable" data-sort="createdAt" onclick={sortBy}>INSCRIPTION {sortArrow('createdAt')}</div>
+        <div class="tableTitleDate sortable" data-sort="lastLogin" onclick={sortBy}>DERNIÈRE CONNEXION {sortArrow('lastLogin')}</div>
+        <div class="tableTitleDate sortable" data-sort="lastExecution" onclick={sortBy}>DERNIÈRE EXÉCUTION {sortArrow('lastExecution')}</div>
         <div class="tableTitleAction">ACTION</div>
       </div>
       <div class="containerV userTableBody">
-        <div class="containerH tableRow userRow" each={users}>
+        <div class="containerH tableRow userRow" each={sortedUsers}>
           <div class="tableRowName">{name || '-'}</div>
-          <div class="tableRowEmail">{credentials.email}</div>
+          <div class="tableRowEmail">{email}</div>
           <div class="tableRowRole">
             <span class={admin? 'admin-badge is-admin' : 'admin-badge'}> {admin? 'admin' : 'user'} </span>
           </div>
+          <div class="tableRowCount">{workspaceCount}</div>
+          <div class="tableRowDate">{formatDate(createdAt)}</div>
+          <div class="tableRowDate">{formatDate(lastLogin)}</div>
+          <div class="tableRowDate">{formatDate(lastExecution)}</div>
           <div class="tableRowAction">
             <button if={!admin} data-user-id={_id} onclick={promoteUser} class="admin-btn promote">Promouvoir admin</button>
             <button if={admin} data-user-id={_id} onclick={demoteUser} class="admin-btn demote">Retirer admin</button>
           </div>
         </div>
       </div>
-      <div if={users.length === 0} class="containerH" style="justify-content:center;">
+      <div if={sortedUsers.length === 0} class="containerH" style="justify-content:center;">
         <div class="containerV" style="flex-basis:1;justify-content:center;margin:50px">
           <h1 style="text-align: center;color: rgb(119,119,119);">Aucun utilisateur.</h1>
         </div>
@@ -76,6 +84,8 @@
   <script>
     this.data = {}
     this.users = []
+    this.sortKey = null
+    this.sortAsc = true
 
     this.refreshData = (data) => {
       this.data = data
@@ -85,6 +95,47 @@
     this.refreshUsers = (users) => {
       this.users = users || []
       this.update()
+    }
+
+    this.sortedUsers = () => {
+      if (!this.sortKey) return this.users
+      const sorted = this.users.slice().sort((a, b) => {
+        let va = a[this.sortKey]
+        let vb = b[this.sortKey]
+        if (va === null || va === undefined) va = ''
+        if (vb === null || vb === undefined) vb = ''
+        if (typeof va === 'number' && typeof vb === 'number') {
+          return this.sortAsc ? va - vb : vb - va
+        }
+        va = String(va)
+        vb = String(vb)
+        return this.sortAsc ? va.localeCompare(vb) : vb.localeCompare(va)
+      })
+      return sorted
+    }
+
+    this.sortBy = (e) => {
+      const key = e.currentTarget.getAttribute('data-sort')
+      if (this.sortKey === key) {
+        this.sortAsc = !this.sortAsc
+      } else {
+        this.sortKey = key
+        this.sortAsc = true
+      }
+      this.update()
+    }
+
+    this.sortArrow = (key) => {
+      if (this.sortKey !== key) return ''
+      return this.sortAsc ? '▲' : '▼'
+    }
+
+    this.formatDate = (d) => {
+      if (!d) return '-'
+      const date = new Date(d)
+      const dd = String(date.getDate()).padStart(2, '0')
+      const mm = String(date.getMonth() + 1).padStart(2, '0')
+      return `${dd}/${mm}/${date.getFullYear()}`
     }
 
     this.promoteUser = (e) => {
@@ -172,6 +223,25 @@
   </script>
   <style>
 
+    /* Bandeau d'onglets : hauteur fixe, non compressible quand la liste est longue */
+    .tab {
+      flex-shrink: 0;
+      height: 48px;
+      min-height: 48px;
+      align-items: center;
+    }
+    .tab button {
+      padding: 12px 18px;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .tabcontent {
+      overflow-y: auto;
+      min-height: 0;
+    }
+
     /* Table utilisateurs — colonnes à largeur fixe (alignées header/lignes) */
     .containerTitle,
     .tableRow,
@@ -179,39 +249,58 @@
     .tableRowEmail,
     .tableRowRole,
     .tableRowAction,
+    .tableRowCount,
+    .tableRowDate,
     .tableTitleName,
     .tableTitleEmail,
     .tableTitleRole,
-    .tableTitleAction {
+    .tableTitleAction,
+    .tableTitleCount,
+    .tableTitleDate {
       box-sizing: border-box;
     }
     .tableRowName,
     .tableTitleName {
-      flex: 0 0 25%;
-      width: 25%;
+      flex: 0 0 14%;
+      width: 14%;
     }
     .tableRowEmail,
     .tableTitleEmail {
-      flex: 0 0 35%;
-      width: 35%;
+      flex: 0 0 18%;
+      width: 18%;
     }
     .tableRowRole,
     .tableTitleRole {
-      flex: 0 0 15%;
-      width: 15%;
+      flex: 0 0 8%;
+      width: 8%;
+    }
+    .tableRowCount,
+    .tableTitleCount {
+      flex: 0 0 9%;
+      width: 9%;
+    }
+    .tableRowDate,
+    .tableTitleDate {
+      flex: 0 0 12%;
+      width: 12%;
     }
     .tableRowAction,
     .tableTitleAction {
-      flex: 0 0 25%;
-      width: 25%;
+      flex: 0 0 15%;
+      width: 15%;
     }
 
     .tableRowName,
     .tableRowEmail,
     .tableRowRole,
+    .tableRowCount,
+    .tableRowDate,
     .tableRowAction {
       font-size: 0.85em;
       padding: 10px;
+    }
+    .tableRowCount {
+      text-align: center;
     }
     .tableRowAction {
       justify-content: flex-end;
@@ -219,7 +308,7 @@
 
     .containerTitle {
       border-radius: 2px;
-      width: 90%;
+      width: 95%;
       flex-direction: row;
       display: flex;
       justify-content: flex-start;
@@ -229,15 +318,31 @@
     .tableTitleName,
     .tableTitleEmail,
     .tableTitleRole,
+    .tableTitleCount,
+    .tableTitleDate,
     .tableTitleAction {
       font-size: 0.85em;
       color: white;
       flex-shrink: 0;
       padding-left: 10px;
     }
+    .tableTitleName.sortable,
+    .tableTitleEmail.sortable,
+    .tableTitleRole.sortable,
+    .tableTitleCount.sortable,
+    .tableTitleDate.sortable {
+      cursor: pointer;
+    }
+    .tableTitleName.sortable:hover,
+    .tableTitleEmail.sortable:hover,
+    .tableTitleRole.sortable:hover,
+    .tableTitleCount.sortable:hover,
+    .tableTitleDate.sortable:hover {
+      text-decoration: underline;
+    }
 
     .userTableBody {
-      width: 90%;
+      width: 95%;
       background-color: white;
     }
     .userRow {

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/main",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Main application module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/main/server/userWebservices.js
+++ b/packages/main/server/userWebservices.js
@@ -45,7 +45,7 @@ module.exports = function (router) {
   // ---------------------------------------  ALL USERS  -----------------------------------------
 
   router.get('/users', (req, res, next) => securityService.wrapperAdmin(req, res, next), function (req, res, next) {
-    user_lib.get_all({}).then(function (users) {
+    user_lib.getAdminUsersStats().then(function (users) {
       res.send(users)
     }).catch(e => {
       next(e)

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/timer",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Timer scheduler module for Semantic Bus",
   "private": true,
   "main": "app.js",


### PR DESCRIPTION
## Résumé

Enrichissement de l'écran admin **Utilisateurs** avec des statistiques par utilisateur
et correction d'un bug graphique du bandeau d'onglets.

## Contenu

**Statistiques users (admin)**
- Nombre de **workflows** par user (aggregation groupée par email).
- Date d'**inscription** (`dates.created_at`).
- **Dernière connexion** (`lastLogin` — nouveau champ, renseigné à chaque authentification
  classique et Google).
- **Dernière exécution** de workflow (aggregation groupée par `ownerId`, dernier `timeStamp`).
- `GET /users` (admin) renvoie désormais ces stats via `user_lib.getAdminUsersStats`.

**Tri**
- Clic sur les en-têtes de colonnes (nom, email, admin, workflows, dates) — tri asc/desc (▲/▼).

**Bug fixé**
- Bandeau d'onglets de l'admin : hauteur fixe (48px) + `flex-shrink:0` — plus de compression
  avec une longue liste d'utilisateurs ; le contenu scrolle (`overflow-y:auto`).

**Release**
- Bump `v0.11.4` (6 package.json) + CHANGELOG.

## Tests
- Main 16, Core 63 (dont tests `getAdminUsersStats`).
- `lastLogin` vérifié en réel (connexion → champ renseigné).