### PR TITLE
ci(lint): ne plus échouer sur master (push auto-format sur branche protégée)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,7 +63,7 @@ jobs:
           fi
 
       - name: Commit formatting changes
-        if: steps.format-check.outputs.changes == 'true' && github.event_name == 'push'
+        if: steps.format-check.outputs.changes == 'true' && github.event_name == 'push' && github.ref_name != 'master' && github.ref_name != 'main' && github.ref_name != 'production'
         run: |
           cd packages/core
           git commit -m "🎨 Auto-format: Core package code formatting
@@ -73,7 +73,7 @@ jobs:
           - [skip ci] to prevent infinite loops" || echo "Nothing to commit"
 
       - name: Push formatting changes
-        if: steps.format-check.outputs.changes == 'true' && github.event_name == 'push'
+        if: steps.format-check.outputs.changes == 'true' && github.event_name == 'push' && github.ref_name != 'master' && github.ref_name != 'main' && github.ref_name != 'production'
         run: |
           echo "🚀 Pushing automatic formatting changes..."
           git push origin ${{ github.ref_name }}
@@ -143,7 +143,7 @@ jobs:
           fi
 
       - name: Commit formatting changes
-        if: steps.format-check.outputs.changes == 'true' && github.event_name == 'push'
+        if: steps.format-check.outputs.changes == 'true' && github.event_name == 'push' && github.ref_name != 'master' && github.ref_name != 'main' && github.ref_name != 'production'
         run: |
           cd packages/main
           git commit -m "🎨 Auto-format: Main package code formatting
@@ -153,7 +153,7 @@ jobs:
           - [skip ci] to prevent infinite loops" || echo "Nothing to commit"
 
       - name: Push formatting changes
-        if: steps.format-check.outputs.changes == 'true' && github.event_name == 'push'
+        if: steps.format-check.outputs.changes == 'true' && github.event_name == 'push' && github.ref_name != 'master' && github.ref_name != 'main' && github.ref_name != 'production'
         run: |
           echo "🚀 Pushing automatic formatting changes..."
           git push origin ${{ github.ref_name }}
@@ -223,7 +223,7 @@ jobs:
           fi
 
       - name: Commit formatting changes
-        if: steps.format-check.outputs.changes == 'true' && github.event_name == 'push'
+        if: steps.format-check.outputs.changes == 'true' && github.event_name == 'push' && github.ref_name != 'master' && github.ref_name != 'main' && github.ref_name != 'production'
         run: |
           cd packages/engine
           git commit -m "🎨 Auto-format: Engine package code formatting
@@ -233,7 +233,7 @@ jobs:
           - [skip ci] to prevent infinite loops" || echo "Nothing to commit"
 
       - name: Push formatting changes
-        if: steps.format-check.outputs.changes == 'true' && github.event_name == 'push'
+        if: steps.format-check.outputs.changes == 'true' && github.event_name == 'push' && github.ref_name != 'master' && github.ref_name != 'main' && github.ref_name != 'production'
         run: |
           echo "🚀 Pushing automatic formatting changes..."
           git push origin ${{ github.ref_name }}
@@ -303,7 +303,7 @@ jobs:
           fi
 
       - name: Commit formatting changes
-        if: steps.format-check.outputs.changes == 'true' && github.event_name == 'push'
+        if: steps.format-check.outputs.changes == 'true' && github.event_name == 'push' && github.ref_name != 'master' && github.ref_name != 'main' && github.ref_name != 'production'
         run: |
           cd packages/timer
           git commit -m "🎨 Auto-format: Timer package code formatting
@@ -313,7 +313,7 @@ jobs:
           - [skip ci] to prevent infinite loops" || echo "Nothing to commit"
 
       - name: Push formatting changes
-        if: steps.format-check.outputs.changes == 'true' && github.event_name == 'push'
+        if: steps.format-check.outputs.changes == 'true' && github.event_name == 'push' && github.ref_name != 'master' && github.ref_name != 'main' && github.ref_name != 'production'
         run: |
           echo "🚀 Pushing automatic formatting changes..."
           git push origin ${{ github.ref_name }}


### PR DESCRIPTION
## Résumé

Le workflow `lint.yml` tentait de **commit + push automatique** des correctifs de formatage
(`lint:fix`) vers la branche courante sur chaque **push** (`github.event_name == 'push'`).

Sur `master` (protégée), ce push échoue en **GH006** (protected branch) → le job passe en
**FAILURE** après chaque merge (`Merge pull request ...` → push master → échec).

## Correctif

Restreint l'auto-push (et l'auto-commit) aux **branches de feature** en excluant
`master` / `main` / `production` :

```yaml
if: ... && github.event_name == 'push' && github.ref_name != 'master' && github.ref_name != 'main' && github.ref_name != 'production'
```

Appliqué aux 4 jobs (core, main, engine, timer) — étapes commit + push.

Sur `master`, le lint vérifie désormais sans tenter de pousser (le job passe en SUCCESS).