### PR TITLE
fix(admin): affiche la liste des utilisateurs (appel de sortedUsers dans le template)

### DIFF
--- a/packages/main/client/static/tag/admin.tag
+++ b/packages/main/client/static/tag/admin.tag
@@ -20,7 +20,7 @@
         <div class="tableTitleAction">ACTION</div>
       </div>
       <div class="containerV userTableBody">
-        <div class="containerH tableRow userRow" each={sortedUsers}>
+        <div class="containerH tableRow userRow" each={sortedUsers()}>
           <div class="tableRowName">{name || '-'}</div>
           <div class="tableRowEmail">{email}</div>
           <div class="tableRowRole">
@@ -36,7 +36,7 @@
           </div>
         </div>
       </div>
-      <div if={sortedUsers.length === 0} class="containerH" style="justify-content:center;">
+      <div if={sortedUsers().length === 0} class="containerH" style="justify-content:center;">
         <div class="containerV" style="flex-basis:1;justify-content:center;margin:50px">
           <h1 style="text-align: center;color: rgb(119,119,119);">Aucun utilisateur.</h1>
         </div>


### PR DESCRIPTION
## Résumé

Bug : le tableau des utilisateurs dans l'écran admin restait **vide** malgré des données
reçues (333 users en prod).

## Cause

`each={sortedUsers}` référençait la **fonction** `sortedUsers` sans l'appeler — Riot
itérait donc sur rien. Il faut `each={sortedUsers()}`.

## Correctif

```diff
- <div class="containerH tableRow userRow" each={sortedUsers}>
+ <div class="containerH tableRow userRow" each={sortedUsers()}>
- <div if={sortedUsers.length === 0} ...>
+ <div if={sortedUsers().length === 0} ...>
```

Le tableau s'affiche (avec tri) et le message « Aucun utilisateur. » n'apparaît que si
la liste est réellement vide.