### PR TITLE
feat(admin): sépare nb workflows owner / contributeur par user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.11.5] - 2026-08-24
+
+### Added
+
+- **Admin — nb de workflows séparé** : les colonnes « OWNER » et « CONTRIBUTEUR »
+  (rôle non-owner) remplacent la colonne unique « WORKFLOWS » dans le tableau des
+  utilisateurs. Les deux sont triables.
+
 ## [0.11.4] - 2026-08-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-bus-monorepo",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "ETL style data middleware transformation embedded in an ESB for all kind of data",
   "private": true,
   "workspaces": [

--- a/packages/core/__tests__/lib/user_lib.admin.test.js
+++ b/packages/core/__tests__/lib/user_lib.admin.test.js
@@ -145,7 +145,10 @@ describe('user_lib.getAdminUsersStats - stats admin (workflows, dates)', () => {
         })
       })
     });
-    workspaceAggregateMock.mockResolvedValue([{ _id: 'alice@example.com', count: 3 }]);
+    workspaceAggregateMock.mockResolvedValue([
+      { _id: { email: 'alice@example.com', role: 'owner' }, count: 2 },
+      { _id: { email: 'alice@example.com', role: 'editor' }, count: 1 }
+    ]);
     processAggregateMock.mockResolvedValue([{ _id: 'u1', lastExecution: new Date('2026-08-20') }]);
   }
 
@@ -156,7 +159,8 @@ describe('user_lib.getAdminUsersStats - stats admin (workflows, dates)', () => {
     const u = res[0];
     expect(u.email).toBe('alice@example.com');
     expect(u.admin).toBe(true);
-    expect(u.workspaceCount).toBe(3);
+    expect(u.workspaceCount).toBe(2);
+    expect(u.contributorCount).toBe(1);
     expect(u.createdAt).toEqual(new Date('2026-01-01'));
     expect(u.lastLogin).toEqual(new Date('2026-08-01'));
     expect(u.lastExecution).toEqual(new Date('2026-08-20'));
@@ -176,6 +180,7 @@ describe('user_lib.getAdminUsersStats - stats admin (workflows, dates)', () => {
     processAggregateMock.mockResolvedValue([]);
     const res = await user_lib.getAdminUsersStats();
     expect(res[0].workspaceCount).toBe(0);
+    expect(res[0].contributorCount).toBe(0);
     expect(res[0].createdAt).toBe(null);
     expect(res[0].lastExecution).toBe(null);
   });

--- a/packages/core/lib/user_lib.js
+++ b/packages/core/lib/user_lib.js
@@ -288,10 +288,10 @@ async function _getWithRelations(userID, config) {
   //   });
 } // <= _getWithWorkspace
 
-// Statistiques admin sur les users : nb de workflows, date d'inscription, dernière
-// connexion, dernière exécution de workflow. Utilisée par la route admin GET /users.
-// Le nb de workflows et la dernière exécution sont calculés par aggregation groupée
-// (une requête par source, pas une par user).
+// Statistiques admin sur les users : nb de workflows (owner/contributeur), date
+// d'inscription, dernière connexion, dernière exécution de workflow. Utilisée par
+// la route admin GET /users. Le nb de workflows et la dernière exécution sont
+// calculés par aggregation groupée (une requête par source, pas une par user).
 async function _getAdminUsersStats() {
   const [users, workspaceCounts, lastProcesses] = await Promise.all([
     userModel.getInstance().model
@@ -302,7 +302,7 @@ async function _getAdminUsersStats() {
 
     workspaceModel.getInstance().model.aggregate([
       { $unwind: '$users' },
-      { $group: { _id: '$users.email', count: { $sum: 1 } } }
+      { $group: { _id: { email: '$users.email', role: '$users.role' }, count: { $sum: 1 } } }
     ]).exec(),
 
     processModel.getInstance().model.aggregate([
@@ -311,7 +311,16 @@ async function _getAdminUsersStats() {
     ]).exec()
   ]);
 
-  const wsMap = new Map(workspaceCounts.map(w => [w._id, w.count]));
+  // Comptes par email, séparés owner vs contributeur (tout rôle non-owner).
+  const wsMap = new Map();
+  for (const w of workspaceCounts) {
+    const email = w._id.email;
+    const isOwner = w._id.role === 'owner';
+    const entry = wsMap.get(email) || { ownerCount: 0, contributorCount: 0 };
+    if (isOwner) entry.ownerCount += w.count;
+    else entry.contributorCount += w.count;
+    wsMap.set(email, entry);
+  }
   const procMap = new Map(lastProcesses.map(p => [p._id.toString(), p.lastExecution]));
 
   return users.map(u => ({
@@ -319,7 +328,8 @@ async function _getAdminUsersStats() {
     name: u.name,
     email: u.credentials.email,
     admin: u.admin === true,
-    workspaceCount: wsMap.get(u.credentials.email) || 0,
+    workspaceCount: (wsMap.get(u.credentials.email) || {}).ownerCount || 0,
+    contributorCount: (wsMap.get(u.credentials.email) || {}).contributorCount || 0,
     createdAt: (u.dates && u.dates.created_at) || null,
     lastLogin: u.lastLogin || null,
     lastExecution: procMap.get(u._id.toString()) || null

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/core",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Core module for Semantic Bus",
   "private": true,
   "main": "index.js",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/engine",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Processing engine module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/eval-service/package.json
+++ b/packages/eval-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/eval-service",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Service d'évaluation JavaScript isolé en container (dédié aux eval des transformations / $where).",
   "private": true,
   "main": "app.js",

--- a/packages/main/client/static/tag/admin.tag
+++ b/packages/main/client/static/tag/admin.tag
@@ -13,7 +13,8 @@
         <div class="tableTitleName sortable" data-sort="name" onclick={sortBy}>NOM {sortArrow('name')}</div>
         <div class="tableTitleEmail sortable" data-sort="email" onclick={sortBy}>EMAIL {sortArrow('email')}</div>
         <div class="tableTitleRole sortable" data-sort="admin" onclick={sortBy}>ADMIN {sortArrow('admin')}</div>
-        <div class="tableTitleCount sortable" data-sort="workspaceCount" onclick={sortBy}>WORKFLOWS {sortArrow('workspaceCount')}</div>
+        <div class="tableTitleCount sortable" data-sort="workspaceCount" onclick={sortBy}>OWNER {sortArrow('workspaceCount')}</div>
+        <div class="tableTitleCount sortable" data-sort="contributorCount" onclick={sortBy}>CONTRIBUTEUR {sortArrow('contributorCount')}</div>
         <div class="tableTitleDate sortable" data-sort="createdAt" onclick={sortBy}>INSCRIPTION {sortArrow('createdAt')}</div>
         <div class="tableTitleDate sortable" data-sort="lastLogin" onclick={sortBy}>DERNIÈRE CONNEXION {sortArrow('lastLogin')}</div>
         <div class="tableTitleDate sortable" data-sort="lastExecution" onclick={sortBy}>DERNIÈRE EXÉCUTION {sortArrow('lastExecution')}</div>
@@ -27,6 +28,7 @@
             <span class={admin? 'admin-badge is-admin' : 'admin-badge'}> {admin? 'admin' : 'user'} </span>
           </div>
           <div class="tableRowCount">{workspaceCount}</div>
+          <div class="tableRowCount">{contributorCount}</div>
           <div class="tableRowDate">{formatDate(createdAt)}</div>
           <div class="tableRowDate">{formatDate(lastLogin)}</div>
           <div class="tableRowDate">{formatDate(lastExecution)}</div>
@@ -272,28 +274,28 @@
     }
     .tableRowEmail,
     .tableTitleEmail {
-      flex: 0 0 18%;
-      width: 18%;
+      flex: 0 0 16%;
+      width: 16%;
     }
     .tableRowRole,
     .tableTitleRole {
-      flex: 0 0 8%;
-      width: 8%;
+      flex: 0 0 7%;
+      width: 7%;
     }
     .tableRowCount,
     .tableTitleCount {
-      flex: 0 0 9%;
-      width: 9%;
+      flex: 0 0 8%;
+      width: 8%;
     }
     .tableRowDate,
     .tableTitleDate {
-      flex: 0 0 12%;
-      width: 12%;
+      flex: 0 0 10%;
+      width: 10%;
     }
     .tableRowAction,
     .tableTitleAction {
-      flex: 0 0 15%;
-      width: 15%;
+      flex: 0 0 12%;
+      width: 12%;
     }
 
     .tableRowName,

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/main",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Main application module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/timer",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Timer scheduler module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/tests/e2e/admin-users-render.js
+++ b/tests/e2e/admin-users-render.js
@@ -69,13 +69,14 @@ function fail(msg) {
     const rows = Array.from(admin.querySelectorAll('.userRow'));
     const header = admin.querySelector('.containerTitle');
     const headerText = header ? header.textContent.replace(/\s+/g, ' ').trim() : '';
-    return { mounted: true, rowCount: rows.length, header: headerText };
+    const firstRowCells = rows[0] ? Array.from(rows[0].querySelectorAll('.tableRowName, .tableRowEmail, .tableRowRole, .tableRowCount, .tableRowDate')).map(c => c.textContent.trim()) : [];
+    return { mounted: true, rowCount: rows.length, header: headerText, firstRowCells };
   });
 
   console.log('Rendu admin:', JSON.stringify(result));
   if (!result.mounted) fail('tag admin non monté');
   if (result.rowCount === 0) fail('aucune ligne user affichée');
-  if (!result.header || !result.header.includes('WORKFLOWS')) fail('header incomplet: ' + result.header);
+  if (!result.header || !result.header.includes('CONTRIBUTEUR')) fail('header incomplet: ' + result.header);
   if (errors.length > 0) fail('erreurs console: ' + errors.join(' | '));
 
   // 4. Vérifier le tri (clic sur l'en-tête WORKFLOWS)


### PR DESCRIPTION
## Résumé

Dans l'écran admin, la colonne unique « WORKFLOWS » est remplacée par **2 colonnes** :
**OWNER** (workflows dont le user est propriétaire) et **CONTRIBUTEUR** (rôle non-owner).

## Contenu

- **`user_lib.getAdminUsersStats`** : aggregation groupée par `email + rôle` —
  `workspaceCount` (owner) et `contributorCount` (tout rôle non-owner).
- **`admin.tag`** : 2 colonnes triables (OWNER / CONTRIBUTEUR).
- Tests unitaires mis à jour (owner=2, contributeur=1 dans le mock).
- Test E2E mis à jour (vérifie le header CONTRIBUTEUR).

**Release** : bump `v0.11.5` + CHANGELOG.

## Validation

- Tests : Core 63, Main 16.
- **E2E réel** (Chromium local) : header OWNER/CONTRIBUTEUR affiché, données correctes
  (Simon : 23 owner / 0 contributeur), 0 erreur console.