### PR TITLE
feat(admin): détail des workflows d'un user (accordéon)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.11.6] - 2026-08-24
+
+### Added
+
+- **Admin — détail des workflows d'un user** : bouton « Détails » par utilisateur →
+  accordéon listant ses workflows (nom, badge owner/contributeur, dernière exécution)
+  avec un lien « Ouvrir ↗ » vers le workflow (nouvel onglet).
+
 ## [0.11.5] - 2026-08-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-bus-monorepo",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "ETL style data middleware transformation embedded in an ESB for all kind of data",
   "private": true,
   "workspaces": [

--- a/packages/core/__tests__/lib/user_lib.admin.test.js
+++ b/packages/core/__tests__/lib/user_lib.admin.test.js
@@ -185,3 +185,53 @@ describe('user_lib.getAdminUsersStats - stats admin (workflows, dates)', () => {
     expect(res[0].lastExecution).toBe(null);
   });
 });
+
+describe('user_lib.getUserWorkflows - détail des workflows d un user', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('retourne les workflows avec rôle et dernière exécution', async () => {
+    // user par id
+    findOneMock.mockReturnValue({
+      select: () => ({
+        lean: () => ({
+          exec: () => Promise.resolve({ _id: 'u1', credentials: { email: 'alice@example.com' } })
+        })
+      })
+    });
+    // workspaces du user
+    findMock.mockReturnValue({
+      select: () => ({
+        lean: () => ({
+          exec: () => Promise.resolve([
+            { _id: 'ws1', name: 'Flux A', users: [{ email: 'alice@example.com', role: 'owner' }] },
+            { _id: 'ws2', name: 'Flux B', users: [{ email: 'alice@example.com', role: 'editor' }] }
+          ])
+        })
+      })
+    });
+    // dernières exécutions par workflow
+    processAggregateMock.mockResolvedValue([
+      { _id: 'ws1', lastExecution: new Date('2026-08-20') }
+    ]);
+
+    const res = await user_lib.getUserWorkflows('u1');
+    expect(res).toHaveLength(2);
+    expect(res[0]).toEqual({
+      _id: 'ws1', name: 'Flux A', role: 'owner', isOwner: true, lastExecution: new Date('2026-08-20')
+    });
+    expect(res[1]).toEqual({
+      _id: 'ws2', name: 'Flux B', role: 'editor', isOwner: false, lastExecution: null
+    });
+  });
+
+  test('lève une erreur si le user est introuvable', async () => {
+    findOneMock.mockReturnValue({
+      select: () => ({
+        lean: () => ({ exec: () => Promise.resolve(null) })
+      })
+    });
+    await expect(user_lib.getUserWorkflows('uX')).rejects.toThrow();
+  });
+});

--- a/packages/core/lib/user_lib.js
+++ b/packages/core/lib/user_lib.js
@@ -29,6 +29,7 @@ module.exports = {
   updateProfil,
   getWithRelations: _getWithRelations,
   getAdminUsersStats: _getAdminUsersStats,
+  getUserWorkflows: _getUserWorkflows,
   userGraph: _userGraph,
   createUpdatePasswordEntity: _createUpdatePasswordEntity,
   getPasswordEntity: _getPasswordEntity,
@@ -335,6 +336,46 @@ async function _getAdminUsersStats() {
     lastExecution: procMap.get(u._id.toString()) || null
   }));
 } // <= _getAdminUsersStats
+
+// Détail des workflows d'un user (admin) : nom, rôle (owner/contributeur),
+// dernière exécution, id du workspace. Utilisée par GET /users/:id/workflows.
+async function _getUserWorkflows(userId) {
+  const user = await userModel.getInstance().model
+    .findOne({ _id: userId })
+    .select('credentials.email')
+    .lean()
+    .exec();
+  if (!user) {
+    throw new Error.EntityNotFoundError('User');
+  }
+  const email = user.credentials.email;
+
+  const [workspaces, lastExecutions] = await Promise.all([
+    workspaceModel.getInstance().model
+      .find({ 'users.email': email })
+      .select('_id name users')
+      .lean()
+      .exec(),
+
+    processModel.getInstance().model.aggregate([
+      { $sort: { timeStamp: -1 } },
+      { $group: { _id: '$workflowId', lastExecution: { $first: '$timeStamp' } } }
+    ]).exec()
+  ]);
+
+  const execMap = new Map(lastExecutions.map(p => [p._id.toString(), p.lastExecution]));
+
+  return workspaces.map(w => {
+    const member = (w.users || []).find(u => u.email === email);
+    return {
+      _id: w._id,
+      name: w.name || '(sans titre)',
+      role: (member && member.role) || 'unknown',
+      isOwner: member ? member.role === 'owner' : false,
+      lastExecution: execMap.get(w._id.toString()) || null
+    };
+  });
+} // <= _getUserWorkflows
 
 function _userGraph(userId) {
   return new Promise(resolve => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/core",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Core module for Semantic Bus",
   "private": true,
   "main": "index.js",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/engine",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Processing engine module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/eval-service/package.json
+++ b/packages/eval-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/eval-service",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Service d'évaluation JavaScript isolé en container (dédié aux eval des transformations / $where).",
   "private": true,
   "main": "app.js",

--- a/packages/main/client/static/store/adminStore.js
+++ b/packages/main/client/static/store/adminStore.js
@@ -88,4 +88,18 @@ function AdminStore (utilStore) {
     })
   })
 
+  this.on('load_user_workflows', (userId) => {
+    return new Promise((resolve, reject) => {
+      this.utilStore.ajaxCall({
+        method: 'get',
+        url: '../data/core/users/' + userId + '/workflows'
+      }, true).then(workflows => {
+        this.trigger('user_workflows_loaded', { userId, workflows })
+        resolve(workflows)
+      }).catch(error => {
+        reject(error)
+      })
+    })
+  })
+
 }

--- a/packages/main/client/static/tag/admin.tag
+++ b/packages/main/client/static/tag/admin.tag
@@ -21,20 +21,44 @@
         <div class="tableTitleAction">ACTION</div>
       </div>
       <div class="containerV userTableBody">
-        <div class="containerH tableRow userRow" each={displayUsers}>
-          <div class="tableRowName">{name || '-'}</div>
-          <div class="tableRowEmail">{email}</div>
-          <div class="tableRowRole">
-            <span class={admin? 'admin-badge is-admin' : 'admin-badge'}> {admin? 'admin' : 'user'} </span>
+        <div class="containerV userRowBlock" each={displayUsers}>
+          <div class="containerH tableRow userRow">
+            <div class="tableRowName">{name || '-'}</div>
+            <div class="tableRowEmail">{email}</div>
+            <div class="tableRowRole">
+              <span class={admin? 'admin-badge is-admin' : 'admin-badge'}> {admin? 'admin' : 'user'} </span>
+            </div>
+            <div class="tableRowCount">{workspaceCount}</div>
+            <div class="tableRowCount">{contributorCount}</div>
+            <div class="tableRowDate">{formatDate(createdAt)}</div>
+            <div class="tableRowDate">{formatDate(lastLogin)}</div>
+            <div class="tableRowDate">{formatDate(lastExecution)}</div>
+            <div class="tableRowAction">
+              <button data-user-id={_id} onclick={toggleWorkflows} class="admin-btn details">Détails</button>
+              <button if={!admin} data-user-id={_id} onclick={promoteUser} class="admin-btn promote">Promouvoir</button>
+              <button if={admin} data-user-id={_id} onclick={demoteUser} class="admin-btn demote">Retirer</button>
+            </div>
           </div>
-          <div class="tableRowCount">{workspaceCount}</div>
-          <div class="tableRowCount">{contributorCount}</div>
-          <div class="tableRowDate">{formatDate(createdAt)}</div>
-          <div class="tableRowDate">{formatDate(lastLogin)}</div>
-          <div class="tableRowDate">{formatDate(lastExecution)}</div>
-          <div class="tableRowAction">
-            <button if={!admin} data-user-id={_id} onclick={promoteUser} class="admin-btn promote">Promouvoir admin</button>
-            <button if={admin} data-user-id={_id} onclick={demoteUser} class="admin-btn demote">Retirer admin</button>
+          <div if={expandedId === _id} class="containerV userWorkflowDetail">
+            <div class="containerV workflowDetailInner">
+              <div if={userWorkflows.length === 0} class="workflowEmpty">Aucun workflow.</div>
+              <div class="containerH workflowRow workflowHeader">
+                <div class="wfCol wfName">NOM</div>
+                <div class="wfCol wfRole">RÔLE</div>
+                <div class="wfCol wfLast">DERNIÈRE EXÉCUTION</div>
+                <div class="wfCol wfAction">OUVRIR</div>
+              </div>
+              <div class="containerH workflowRow" each={userWorkflows}>
+                <div class="wfCol wfName">{name}</div>
+                <div class="wfCol wfRole">
+                  <span class={isOwner? 'wf-badge is-owner' : 'wf-badge is-contributor'}> {isOwner? 'owner' : 'contributeur'} </span>
+                </div>
+                <div class="wfCol wfLast">{formatDate(lastExecution)}</div>
+                <div class="wfCol wfAction">
+                  <a href={'application.html#workspace/' + _id + '/component'} target="_blank" class="wf-open">Ouvrir ↗</a>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -89,10 +113,33 @@
     this.displayUsers = []
     this.sortKey = null
     this.sortAsc = true
+    this.expandedId = null
+    this.userWorkflows = []
 
     this.refreshData = (data) => {
       this.data = data
       this.update()
+    }
+
+    this.toggleWorkflows = (e) => {
+      const userId = (e && e.currentTarget && e.currentTarget.getAttribute('data-user-id'))
+      if (this.expandedId === userId) {
+        this.expandedId = null
+        this.userWorkflows = []
+        this.update()
+      } else {
+        this.expandedId = userId
+        this.userWorkflows = []
+        RiotControl.trigger('load_user_workflows', userId)
+        this.update()
+      }
+    }
+
+    this.userWorkflowsLoaded = (data) => {
+      if (data && data.userId === this.expandedId) {
+        this.userWorkflows = data.workflows || []
+        this.update()
+      }
     }
 
     this.refreshUsers = (users) => {
@@ -218,6 +265,7 @@
       RiotControl.on('timers_executed', this.timersExecuted);
       RiotControl.on('users_loaded', this.refreshUsers);
       RiotControl.on('user_admin_changed', this.userAdminChanged);
+      RiotControl.on('user_workflows_loaded', this.userWorkflowsLoaded);
       RiotControl.trigger('load_users');
     })
 
@@ -227,6 +275,7 @@
       RiotControl.off('timers_executed', this.timersExecuted);
       RiotControl.off('users_loaded', this.refreshUsers);
       RiotControl.off('user_admin_changed', this.userAdminChanged);
+      RiotControl.off('user_workflows_loaded', this.userWorkflowsLoaded);
     })
   </script>
   <style>
@@ -428,6 +477,65 @@
     }
     .admin-btn.demote:hover {
       background-color: #e55a54;
+    }
+    .admin-btn.details {
+      background-color: rgb(90,150,190);
+    }
+    .admin-btn.details:hover {
+      background-color: rgb(70,130,170);
+    }
+
+    /* Accordéon détail des workflows d'un user */
+    .userWorkflowDetail {
+      width: 100%;
+      background-color: rgb(244,247,250);
+      border-left: 3px solid rgb(26,145,194);
+    }
+    .workflowDetailInner {
+      width: 100%;
+      padding: 12px 20px;
+    }
+    .workflowEmpty {
+      color: rgb(140,150,160);
+      font-size: 0.9em;
+      padding: 8px 0;
+    }
+    .workflowRow {
+      width: 100%;
+      align-items: center;
+      padding: 6px 0;
+      border-bottom: 1px solid #e4e9ef;
+    }
+    .workflowHeader {
+      font-weight: 600;
+      color: rgb(80,90,100);
+      font-size: 0.8em;
+      text-transform: uppercase;
+    }
+    .wfCol {
+      font-size: 0.85em;
+      padding: 0 8px;
+    }
+    .wfName { flex: 0 0 40%; width: 40%; }
+    .wfRole { flex: 0 0 20%; width: 20%; }
+    .wfLast { flex: 0 0 25%; width: 25%; }
+    .wfAction { flex: 0 0 15%; width: 15%; }
+    .wf-badge {
+      padding: 3px 10px;
+      border-radius: 10px;
+      color: white;
+      font-size: 0.75em;
+      text-transform: uppercase;
+    }
+    .wf-badge.is-owner { background-color: rgb(26,145,194); }
+    .wf-badge.is-contributor { background-color: rgb(170,180,190); }
+    .wf-open {
+      color: rgb(26,145,194);
+      text-decoration: none;
+      font-size: 0.85em;
+    }
+    .wf-open:hover {
+      text-decoration: underline;
     }
   </style>
 </admin>

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/main",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Main application module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/main/server/userWebservices.js
+++ b/packages/main/server/userWebservices.js
@@ -88,6 +88,17 @@ module.exports = function (router) {
 
   // ---------------------------------------------------------------------------------
 
+  router.get('/users/:id/workflows', (req, res, next) => securityService.wrapperAdmin(req, res, next), async function (req, res, next) {
+    try {
+      const workflows = await user_lib.getUserWorkflows(req.params.id)
+      res.send(workflows)
+    } catch (e) {
+      next(e)
+    }
+  }) // <= get_user_workflows
+
+  // ---------------------------------------------------------------------------------
+
   router.post('/users/mail', async (req, res, next) => {
     try {
       const token = encodeToken(req.query.mail, 'verify')

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/timer",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Timer scheduler module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/tests/e2e/admin-users-render.js
+++ b/tests/e2e/admin-users-render.js
@@ -79,13 +79,41 @@ function fail(msg) {
   if (!result.header || !result.header.includes('CONTRIBUTEUR')) fail('header incomplet: ' + result.header);
   if (errors.length > 0) fail('erreurs console: ' + errors.join(' | '));
 
-  // 4. Vérifier le tri (clic sur l'en-tête WORKFLOWS)
+  // 4. Vérifier l'accordéon « Détails » des workflows d'un user
+  await page.evaluate(() => {
+    const btn = document.querySelector('admin .admin-btn.details');
+    btn.click();
+  });
+  await page.waitForTimeout(2500);
+
+  const accord = await page.evaluate(() => {
+    const admin = document.querySelector('admin');
+    const detail = admin.querySelector('.userWorkflowDetail');
+    if (!detail) return { accordeon: false };
+    const rows = Array.from(detail.querySelectorAll('.workflowRow:not(.workflowHeader)'));
+    const links = Array.from(detail.querySelectorAll('.wf-open'));
+    return {
+      accordeon: true,
+      visible: getComputedStyle(detail).display !== 'none',
+      workflowRows: rows.length,
+      hasHeader: !!detail.querySelector('.workflowHeader'),
+      hasLink: links.length > 0
+    };
+  });
+  console.log('Accordéon:', JSON.stringify(accord));
+  if (!accord.accordeon || !accord.visible) fail('accordéon non ouvert');
+  if (!accord.hasHeader) fail('accordéon sans header');
+  if (accord.workflowRows === 0) fail('aucun workflow affiché');
+  if (!accord.hasLink) fail('aucun lien Ouvrir');
+  if (errors.length > 0) fail('erreurs console: ' + errors.join(' | '));
+
+  // 5. Vérifier le tri (clic sur l'en-tête WORKFLOWS)
   await page.evaluate(() => {
     const th = document.querySelector('admin .tableTitleCount');
     th.click();
   });
   await page.waitForTimeout(500);
 
-  console.log('✅ Rendu admin OK : ' + result.rowCount + ' user(s) affichés, tri OK, 0 erreur console');
+  console.log('✅ Rendu admin OK : ' + result.rowCount + ' user(s) affichés, tri OK, accordéon OK, 0 erreur console');
   await browser.close();
 })().catch(e => { console.error('❌ FATAL', e.message); process.exit(1); });


### PR DESCRIPTION
## Résumé

Dans l'écran admin, un bouton **« Détails »** par utilisateur ouvre un **accordéon**
listant ses workflows : nom, badge owner/contributeur, dernière exécution, et un lien
**« Ouvrir ↗ »** vers le workflow (nouvel onglet).

## Contenu

- **`user_lib.getUserWorkflows`** : liste les workspaces du user (par email) avec
  nom, rôle (owner/contributeur), dernière exécution (dernier `timeStamp` des process
  groupé par `workflowId`).
- **Route admin** `GET /users/:id/workflows` (`wrapperAdmin`).
- **`adminStore`** : action `load_user_workflows`.
- **`admin.tag`** : bouton « Détails » + accordéon sous la ligne (badge de rôle,
  date, lien `application.html#workspace/:id/component` en `target=_blank`).
- Tests unitaires `getUserWorkflows` + test E2E accordéon.

**Release** : bump `v0.11.6` + CHANGELOG.

## Validation

- Tests : Core 65, Main 16.
- **E2E réel** (Chromium local) : clic « Détails » → accordéon avec 23 workflows,
  header + liens « Ouvrir ↗ » présents, 0 erreur console.