### PR TITLE
release: sync production to v0.11.7 (fix lignes admin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.11.7] - 2026-08-24
+
+### Fixed
+
+- **Admin — lignes du tableau des utilisateurs** : avec beaucoup d'utilisateurs, les
+  lignes étaient compressées (hauteur quasi nulle → invisibles) à cause du
+  `flex-shrink:1` imposé par `flex.css`. Les lignes gardent désormais leur hauteur
+  (`flex-shrink:0`) et le tableau **scrolle** (conteneur `overflow-y:auto`).
+
 ## [0.11.6] - 2026-08-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-bus-monorepo",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "ETL style data middleware transformation embedded in an ESB for all kind of data",
   "private": true,
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/core",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Core module for Semantic Bus",
   "private": true,
   "main": "index.js",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/engine",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Processing engine module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/eval-service/package.json
+++ b/packages/eval-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/eval-service",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Service d'évaluation JavaScript isolé en container (dédié aux eval des transformations / $where).",
   "private": true,
   "main": "app.js",

--- a/packages/main/client/static/tag/admin.tag
+++ b/packages/main/client/static/tag/admin.tag
@@ -8,7 +8,7 @@
 
   <!--  contenu du tab Utilisateurs  -->
   <div id="users" class="containerV tabcontent" style="flex-grow:1; background-color: rgb(238,242,249);">
-    <div class="containerV" style="flex-grow:1;width:95%;align-self:center;">
+    <div class="containerV" style="flex-grow:1;width:95%;align-self:center;min-height:0;overflow-y:auto;">
       <div class="containerTitle">
         <div class="tableTitleName sortable" data-sort="name" onclick={sortBy}>NOM {sortArrow('name')}</div>
         <div class="tableTitleEmail sortable" data-sort="email" onclick={sortBy}>EMAIL {sortArrow('email')}</div>
@@ -299,6 +299,19 @@
       min-height: 0;
     }
 
+    /* Les lignes de users ne doivent jamais être compressées (hauteur fine/invisible)
+       quand la liste est longue : le tabcontent scroll, les lignes gardent leur taille.
+       NB : flex.css impose .containerV>.containerV { flex-shrink:1 } — il faut !important. */
+    .userRowBlock {
+      flex-shrink: 0 !important;
+    }
+    .userRowBlock > .userRow {
+      flex-shrink: 0 !important;
+    }
+    .userTableBody {
+      flex-shrink: 0 !important;
+    }
+
     /* Table utilisateurs — colonnes à largeur fixe (alignées header/lignes) */
     .containerTitle,
     .tableRow,
@@ -401,6 +414,8 @@
     .userTableBody {
       width: 95%;
       background-color: white;
+      overflow: visible;
+      min-height: 0;
     }
     .userRow {
       border-bottom: 1px solid #f2f3f5;

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/main",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Main application module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/timer",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "Timer scheduler module for Semantic Bus",
   "private": true,
   "main": "app.js",


### PR DESCRIPTION
## Résumé

Sync de `production` avec `master` → **v0.11.7**.

## Contenu

- **Fix admin** : lignes du tableau des utilisateurs compressées (invisibles) avec
  longue liste → hauteur conservée + scroll.
- Bump v0.11.7 + CHANGELOG.