### PR TITLE
feat(admin): suppression d'un utilisateur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.11.8] - 2026-08-24
+
+### Added
+
+- **Admin — suppression d'un utilisateur** : bouton « Supprimer » (avec confirmation).
+  Refusé si le compte est propriétaire de workflow(s) ou si c'est le compte de l'admin
+  connecté. La suppression retire le user des workspaces où il est contributeur.
+
 ## [0.11.7] - 2026-08-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-bus-monorepo",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "ETL style data middleware transformation embedded in an ESB for all kind of data",
   "private": true,
   "workspaces": [

--- a/packages/core/__tests__/lib/user_lib.admin.test.js
+++ b/packages/core/__tests__/lib/user_lib.admin.test.js
@@ -9,27 +9,38 @@ jest.mock('../../models/user_model', () => {
   const countDocuments = jest.fn();
   const findByIdAndUpdate = jest.fn();
   const find = jest.fn();
+  const deleteOne = jest.fn();
   return {
     __findOne: findOne,
     __countDocuments: countDocuments,
     __findByIdAndUpdate: findByIdAndUpdate,
     __find: find,
-    getInstance: jest.fn(() => ({ model: { findOne, countDocuments, findByIdAndUpdate, find } }))
+    __deleteOne: deleteOne,
+    getInstance: jest.fn(() => ({ model: { findOne, countDocuments, findByIdAndUpdate, find, deleteOne } }))
   };
 });
 jest.mock('../../models', () => {
   const find = jest.fn();
   const workspaceAggregate = jest.fn();
   const processAggregate = jest.fn();
+  const workspaceFindOne = jest.fn();
+  const workspaceUpdateMany = jest.fn();
+  const authDeleteMany = jest.fn();
   return {
     __find: find,
     __workspaceAggregate: workspaceAggregate,
     __processAggregate: processAggregate,
+    __workspaceFindOne: workspaceFindOne,
+    __workspaceUpdateMany: workspaceUpdateMany,
+    __authDeleteMany: authDeleteMany,
     workspace: {
-      getInstance: jest.fn(() => ({ model: { find, aggregate: () => ({ exec: workspaceAggregate }) } }))
+      getInstance: jest.fn(() => ({ model: { find, findOne: workspaceFindOne, updateMany: workspaceUpdateMany, aggregate: () => ({ exec: workspaceAggregate }) } }))
     },
     process: {
       getInstance: jest.fn(() => ({ model: { aggregate: () => ({ exec: processAggregate }) } }))
+    },
+    authentication: {
+      getInstance: jest.fn(() => ({ model: { deleteMany: authDeleteMany } }))
     },
     historiqueEnd: {},
     certificate: {}
@@ -51,6 +62,9 @@ const countDocumentsMock = userModel.__countDocuments;
 const findMock = models.__find;
 const workspaceAggregateMock = models.__workspaceAggregate;
 const processAggregateMock = models.__processAggregate;
+const workspaceFindOneMock = models.__workspaceFindOne;
+const workspaceUpdateManyMock = models.__workspaceUpdateMany;
+const authDeleteManyMock = models.__authDeleteMany;
 
 describe('user_lib.getWithRelations - défaut admin (moindre privilège)', () => {
   function mockModels(email, admin = false) {
@@ -233,5 +247,54 @@ describe('user_lib.getUserWorkflows - détail des workflows d un user', () => {
       })
     });
     await expect(user_lib.getUserWorkflows('uX')).rejects.toThrow();
+  });
+});
+
+describe('user_lib.deleteUser - suppression d un user (admin)', () => {
+  const userDeleteOneMock = userModel.__deleteOne;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function mockUserFound() {
+    findOneMock.mockReturnValue({
+      select: () => ({
+        lean: () => ({ exec: () => Promise.resolve({ _id: 'u1', credentials: { email: 'bob@example.com' } }) })
+      })
+    });
+  }
+
+  test('refuse si le user est owner d un workspace', async () => {
+    mockUserFound();
+    workspaceFindOneMock.mockReturnValue({
+      select: () => ({ lean: () => ({ exec: () => Promise.resolve({ _id: 'ws1' }) }) })
+    });
+    await expect(user_lib.deleteUser('u1')).rejects.toMatchObject({ code: 'USER_IS_WORKSPACE_OWNER' });
+  });
+
+  test('retire les contributions et supprime le user + auths', async () => {
+    mockUserFound();
+    workspaceFindOneMock.mockReturnValue({
+      select: () => ({ lean: () => ({ exec: () => Promise.resolve(null) }) })
+    });
+    workspaceUpdateManyMock.mockReturnValue({ exec: () => Promise.resolve({ modifiedCount: 1 }) });
+    authDeleteManyMock.mockReturnValue({ exec: () => Promise.resolve({ deletedCount: 2 }) });
+    userDeleteOneMock.mockReturnValue({ exec: () => Promise.resolve({ deletedCount: 1 }) });
+
+    const res = await user_lib.deleteUser('u1');
+    expect(res).toEqual({ deleted: true, email: 'bob@example.com' });
+    expect(workspaceUpdateManyMock).toHaveBeenCalledWith(
+      { 'users.email': 'bob@example.com' },
+      { $pull: { users: { email: 'bob@example.com' } } }
+    );
+    expect(authDeleteManyMock).toHaveBeenCalledWith({ user: 'u1' });
+  });
+
+  test('lève une erreur si le user est introuvable', async () => {
+    findOneMock.mockReturnValue({
+      select: () => ({ lean: () => ({ exec: () => Promise.resolve(null) }) })
+    });
+    await expect(user_lib.deleteUser('uX')).rejects.toThrow();
   });
 });

--- a/packages/core/lib/user_lib.js
+++ b/packages/core/lib/user_lib.js
@@ -8,6 +8,7 @@ const historiqueModel = require('../models').historiqueEnd;
 const SecureMailModel = require('../models/security_mail');
 const workspaceModel = require('../models').workspace;
 const processModel = require('../models').process;
+const authenticationModel = require('../models').authentication;
 const certificateModel = require('../models').certificate;
 // let bigdataflowModel = require("../models").bigdataflow;
 const Error = require('../helpers/error.js');
@@ -30,6 +31,7 @@ module.exports = {
   getWithRelations: _getWithRelations,
   getAdminUsersStats: _getAdminUsersStats,
   getUserWorkflows: _getUserWorkflows,
+  deleteUser: _deleteUser,
   userGraph: _userGraph,
   createUpdatePasswordEntity: _createUpdatePasswordEntity,
   getPasswordEntity: _getPasswordEntity,
@@ -376,6 +378,49 @@ async function _getUserWorkflows(userId) {
     };
   });
 } // <= _getUserWorkflows
+
+// Suppression d'un user (admin) :
+// - refusée si le user est owner d'au moins un workspace (sinon données orphelines) ;
+// - retire le user (email) des workspaces où il est contributeur ;
+// - supprime le user et ses authentifications.
+// L'auto-suppression est gérée au niveau de la route (wrapperAdmin + check caller).
+async function _deleteUser(userId) {
+  const user = await userModel.getInstance().model
+    .findOne({ _id: userId })
+    .select('credentials.email')
+    .lean()
+    .exec();
+  if (!user) {
+    throw new Error.EntityNotFoundError('User');
+  }
+  const email = user.credentials.email;
+
+  // Interdire la suppression si le user est owner d'un workspace.
+  const ownedWorkspaces = await workspaceModel.getInstance().model
+    .findOne({ 'users.email': email, 'users.role': 'owner' })
+    .select('_id')
+    .lean()
+    .exec();
+  if (ownedWorkspaces) {
+    const err = new global.Error('user_is_workspace_owner');
+    err.code = 'USER_IS_WORKSPACE_OWNER';
+    throw err;
+  }
+
+  // Retirer le user des workspaces où il est contributeur (email retiré de users[]).
+  await workspaceModel.getInstance().model.updateMany(
+    { 'users.email': email },
+    { $pull: { users: { email } } }
+  ).exec();
+
+  // Supprimer les authentifications puis le user.
+  await authenticationModel.getInstance().model.deleteMany({ user: userId }).exec();
+  const result = await userModel.getInstance().model.deleteOne({ _id: userId }).exec();
+  if (!result.deletedCount) {
+    throw new Error.EntityNotFoundError('User');
+  }
+  return { deleted: true, email };
+} // <= _deleteUser
 
 function _userGraph(userId) {
   return new Promise(resolve => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/core",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "Core module for Semantic Bus",
   "private": true,
   "main": "index.js",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/engine",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "Processing engine module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/eval-service/package.json
+++ b/packages/eval-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/eval-service",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "Service d'évaluation JavaScript isolé en container (dédié aux eval des transformations / $where).",
   "private": true,
   "main": "app.js",

--- a/packages/main/client/static/store/adminStore.js
+++ b/packages/main/client/static/store/adminStore.js
@@ -102,4 +102,18 @@ function AdminStore (utilStore) {
     })
   })
 
+  this.on('delete_user', (userId) => {
+    return new Promise((resolve, reject) => {
+      this.utilStore.ajaxCall({
+        method: 'delete',
+        url: '../data/core/users/' + userId
+      }, true).then(data => {
+        this.trigger('user_deleted', { userId })
+        resolve(data)
+      }).catch(error => {
+        reject(error)
+      })
+    })
+  })
+
 }

--- a/packages/main/client/static/tag/admin.tag
+++ b/packages/main/client/static/tag/admin.tag
@@ -37,6 +37,7 @@
               <button data-user-id={_id} onclick={toggleWorkflows} class="admin-btn details">Détails</button>
               <button if={!admin} data-user-id={_id} onclick={promoteUser} class="admin-btn promote">Promouvoir</button>
               <button if={admin} data-user-id={_id} onclick={demoteUser} class="admin-btn demote">Retirer</button>
+              <button data-user-id={_id} onclick={deleteUserClick} class="admin-btn delete">Supprimer</button>
             </div>
           </div>
           <div if={expandedId === _id} class="containerV userWorkflowDetail">
@@ -138,6 +139,25 @@
     this.userWorkflowsLoaded = (data) => {
       if (data && data.userId === this.expandedId) {
         this.userWorkflows = data.workflows || []
+        this.update()
+      }
+    }
+
+    this.deleteUserClick = (e) => {
+      const userId = (e && e.currentTarget && e.currentTarget.getAttribute('data-user-id'))
+      const email = (this.users.find(u => u._id == userId) || {}).email || ''
+      if (!confirm('Supprimer définitivement le compte ' + email + ' ?')) return
+      RiotControl.trigger('delete_user', userId)
+    }
+
+    this.userDeleted = (data) => {
+      if (data && data.userId) {
+        this.users = this.users.filter(u => u._id != data.userId)
+        if (this.expandedId === data.userId) {
+          this.expandedId = null
+          this.userWorkflows = []
+        }
+        this.computeDisplay()
         this.update()
       }
     }
@@ -266,6 +286,7 @@
       RiotControl.on('users_loaded', this.refreshUsers);
       RiotControl.on('user_admin_changed', this.userAdminChanged);
       RiotControl.on('user_workflows_loaded', this.userWorkflowsLoaded);
+      RiotControl.on('user_deleted', this.userDeleted);
       RiotControl.trigger('load_users');
     })
 
@@ -276,6 +297,7 @@
       RiotControl.off('users_loaded', this.refreshUsers);
       RiotControl.off('user_admin_changed', this.userAdminChanged);
       RiotControl.off('user_workflows_loaded', this.userWorkflowsLoaded);
+      RiotControl.off('user_deleted', this.userDeleted);
     })
   </script>
   <style>
@@ -498,6 +520,12 @@
     }
     .admin-btn.details:hover {
       background-color: rgb(70,130,170);
+    }
+    .admin-btn.delete {
+      background-color: #d9534f;
+    }
+    .admin-btn.delete:hover {
+      background-color: #c9302c;
     }
 
     /* Accordéon détail des workflows d'un user */

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/main",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "Main application module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/main/server/userWebservices.js
+++ b/packages/main/server/userWebservices.js
@@ -99,6 +99,30 @@ module.exports = function (router) {
 
   // ---------------------------------------------------------------------------------
 
+  router.delete('/users/:id', (req, res, next) => securityService.wrapperAdmin(req, res, next), async function (req, res, next) {
+    try {
+      const callerId = UserIdFromToken(req)
+      if (req.params.id == callerId) {
+        return res.status(400).send({
+          success: false,
+          message: 'Vous ne pouvez pas supprimer votre propre compte.'
+        })
+      }
+      const result = await user_lib.deleteUser(req.params.id)
+      res.send(result)
+    } catch (e) {
+      if (e && e.code === 'USER_IS_WORKSPACE_OWNER') {
+        return res.status(400).send({
+          success: false,
+          message: 'Ce compte est propriétaire de workflow(s) et ne peut pas être supprimé.'
+        })
+      }
+      next(e)
+    }
+  }) // <= delete_user
+
+  // ---------------------------------------------------------------------------------
+
   router.post('/users/mail', async (req, res, next) => {
     try {
       const token = encodeToken(req.query.mail, 'verify')

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/timer",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "Timer scheduler module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/tests/e2e/admin-users-render.js
+++ b/tests/e2e/admin-users-render.js
@@ -114,6 +114,19 @@ function fail(msg) {
   });
   await page.waitForTimeout(500);
 
-  console.log('✅ Rendu admin OK : ' + result.rowCount + ' user(s) affichés, tri OK, accordéon OK, 0 erreur console');
+  // 6. Vérifier la garde de suppression : l'admin ne peut pas se supprimer lui-même (400)
+  const selfDelete = await page.evaluate(async (adminEmail) => {
+    const token = localStorage.token;
+    const listResp = await fetch('/data/core/users', { headers: { Authorization: 'JTW ' + token } });
+    const users = await listResp.json();
+    const me = users.find(u => u.email === adminEmail);
+    if (!me) return { status: 'no-me' };
+    const r = await fetch('/data/core/users/' + me._id, { method: 'DELETE', headers: { Authorization: 'JTW ' + token } });
+    return { status: r.status };
+  }, ADMIN_EMAIL);
+  console.log('Auto-suppression:', JSON.stringify(selfDelete));
+  if (selfDelete.status !== 400) fail('l admin peut se supprimer lui-même (statut=' + selfDelete.status + ')');
+
+  console.log('✅ Rendu admin OK : ' + result.rowCount + ' user(s) affichés, tri OK, accordéon OK, suppression gardée, 0 erreur console');
   await browser.close();
 })().catch(e => { console.error('❌ FATAL', e.message); process.exit(1); });


### PR DESCRIPTION
## Résumé

Permet à un admin de **supprimer un utilisateur** depuis l'écran admin.

## Règles

- **Refus** si le compte est **propriétaire** d'au moins un workflow (sinon données
  orphelines) → 400 « Ce compte est propriétaire de workflow(s)... ».
- **Refus de l'auto-suppression** (l'admin connecté ne peut pas se supprimer) → 400.
- La suppression **retire le user** des workspaces où il est **contributeur** (email
  retiré de `users[]`), puis supprime le user + ses authentifications.

## Contenu

- **`user_lib.deleteUser`** : logique de suppression avec garde owner + nettoyage.
- **Route admin** `DELETE /users/:id` (`wrapperAdmin`).
- **`adminStore`** : action `delete_user` ; **`admin.tag`** : bouton « Supprimer »
  (confirm) + retrait de la ligne après succès.
- Tests unitaires `deleteUser` + E2E (garde auto-suppression 400).

**Release** : bump `v0.11.8` + CHANGELOG.

## Validation

- Tests : Core 68, Main 16.
- **E2E réel** (Chromium local) : contributeur supprimé (200), owner refusé (400),
  auto-suppression refusée (400), bouton « Supprimer » rendu, 0 erreur console.