### PR TITLE
fix(admin): garde owner de suppression — $elemMatch (faux positif contributeur)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.11.9] - 2026-08-24
+
+### Fixed
+
+- **Admin — suppression d'un utilisateur** : la garde « propriétaire de workflow(s) »
+  utilisait un filtre qui pouvait matcher deux membres différents du workspace → un
+  simple **contributeur** était refusé à tort. Corrigé avec `$elemMatch` (même membre).
+
 ## [0.11.8] - 2026-08-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-bus-monorepo",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "ETL style data middleware transformation embedded in an ESB for all kind of data",
   "private": true,
   "workspaces": [

--- a/packages/core/__tests__/lib/user_lib.admin.test.js
+++ b/packages/core/__tests__/lib/user_lib.admin.test.js
@@ -271,6 +271,11 @@ describe('user_lib.deleteUser - suppression d un user (admin)', () => {
       select: () => ({ lean: () => ({ exec: () => Promise.resolve({ _id: 'ws1' }) }) })
     });
     await expect(user_lib.deleteUser('u1')).rejects.toMatchObject({ code: 'USER_IS_WORKSPACE_OWNER' });
+    // La garde owner doit utiliser $elemMatch (pas un filtre plat qui matcherait
+    // deux éléments différents du tableau users).
+    expect(workspaceFindOneMock).toHaveBeenCalledWith(
+      { users: { $elemMatch: { email: 'bob@example.com', role: 'owner' } } }
+    );
   });
 
   test('retire les contributions et supprime le user + auths', async () => {

--- a/packages/core/lib/user_lib.js
+++ b/packages/core/lib/user_lib.js
@@ -396,8 +396,11 @@ async function _deleteUser(userId) {
   const email = user.credentials.email;
 
   // Interdire la suppression si le user est owner d'un workspace.
+  // NB : $elemMatch est obligatoire — un filtre { 'users.email': email, 'users.role': 'owner' }
+  // matcherait un document dont DEUX éléments différents satisfont chacun une clause
+  // (ex. email editor + role owner sur un autre membre), d'où un faux positif.
   const ownedWorkspaces = await workspaceModel.getInstance().model
-    .findOne({ 'users.email': email, 'users.role': 'owner' })
+    .findOne({ users: { $elemMatch: { email, role: 'owner' } } })
     .select('_id')
     .lean()
     .exec();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/core",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "Core module for Semantic Bus",
   "private": true,
   "main": "index.js",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/engine",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "Processing engine module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/eval-service/package.json
+++ b/packages/eval-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/eval-service",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "Service d'évaluation JavaScript isolé en container (dédié aux eval des transformations / $where).",
   "private": true,
   "main": "app.js",

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/main",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "Main application module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/timer",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "Timer scheduler module for Semantic Bus",
   "private": true,
   "main": "app.js",


### PR DESCRIPTION
## Résumé

Un **simple contributeur** était refusé à la suppression comme « propriétaire de
workflow(s) » (signalé en prod avec `simon.louvet.test@gmail.com`, 2 contributeurs).

## Cause

`workspaceModel.findOne({ 'users.email': email, 'users.role': 'owner' })` : MongoDB
matche un document si **deux éléments différents** du tableau `users` satisfont chacun
une clause (email d'un editor + role owner d'un autre membre). Vérifié en base : le filtre
plat matchait 2 workspaces, alors que `simon.louvet.test@gmail.com` n'est owner d'aucun.

## Correctif

```diff
- .findOne({ 'users.email': email, 'users.role': 'owner' })
+ .findOne({ users: { $elemMatch: { email, role: 'owner' } } })
```

`$elemMatch` exige que le **même élément** du tableau matche email ET role. Vérifié en
base : 0 workspace avec le filtre corrigé.

## Tests

- Assertion ajoutée : la garde appelle bien avec `$elemMatch`.
- Core 68, Main 16, lint 0 erreur.

**Release** : bump `v0.11.9` + CHANGELOG.