### PR TITLE
fix(security): confused deputy sur les routes sœurs (SB-IDOR-2026-01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.11.10] - 2026-08-24
+
+### Security
+
+- **Confused deputy sur les routes sœurs** (signalé par Maxim Yakovlev) : les routes
+  `PUT /workspaces/:id`, `PUT /workspaces/:id/components` et
+  `DELETE /workspaces/:id/components` autorisaient sur `req.params.id` mais écrivaient
+  sur `req.body._id` (jamais vérifié) → cross-tenant overwrite, **ownership takeover**,
+  update/create/delete arbitraire de composants. La cible d'écriture est désormais liée
+  à `req.params.id`, et les routes composants vérifient que le composant appartient au
+  workspace autorisé.
+
 ## [0.11.9] - 2026-08-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-bus-monorepo",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "description": "ETL style data middleware transformation embedded in an ESB for all kind of data",
   "private": true,
   "workspaces": [

--- a/packages/core/__tests__/lib/workspace_component_security.test.js
+++ b/packages/core/__tests__/lib/workspace_component_security.test.js
@@ -1,0 +1,55 @@
+// Test de sécurité — workspace_component_lib.assertComponentInWorkspace
+// (SB-IDOR-2026-01, confused deputy sur les routes composants).
+
+jest.mock('../../models/workspace_component_model', () => {
+  const findOne = jest.fn();
+  return {
+    __findOne: findOne,
+    getInstance: jest.fn(() => ({ model: { findOne } }))
+  };
+});
+jest.mock('../../models/workspace_model', () => ({
+  getInstance: jest.fn(() => ({ model: {} }))
+}));
+jest.mock('../../models/historiqueEnd_model', () => ({
+  getInstance: jest.fn(() => ({ model: {} }))
+}));
+jest.mock('../../helpers/error.js', () => ({}));
+jest.mock('../../lib/specificDataValidator.js', () => ({ validateSpecificData: jest.fn(v => v) }));
+
+const workspaceComponentModel = require('../../models/workspace_component_model');
+const workspaceComponentLib = require('../../lib/workspace_component_lib.js');
+
+const findOneMock = workspaceComponentModel.__findOne;
+
+describe('workspace_component_lib.assertComponentInWorkspace', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('autorise un composant appartenant au workspace autorisé', async () => {
+    findOneMock.mockReturnValue({
+      select: () => ({ lean: () => ({ exec: () => Promise.resolve({ _id: 'comp', workspaceId: 'ws1' }) }) })
+    });
+    const c = await workspaceComponentLib.assertComponentInWorkspace('comp', 'ws1');
+    expect(c._id).toBe('comp');
+  });
+
+  test('refuse un composant d un autre workspace', async () => {
+    findOneMock.mockReturnValue({
+      select: () => ({ lean: () => ({ exec: () => Promise.resolve({ _id: 'comp', workspaceId: 'ws2' }) }) })
+    });
+    await expect(workspaceComponentLib.assertComponentInWorkspace('comp', 'ws1')).rejects.toMatchObject({ status: 403 });
+  });
+
+  test('refuse un composant inexistant', async () => {
+    findOneMock.mockReturnValue({
+      select: () => ({ lean: () => ({ exec: () => Promise.resolve(null) }) })
+    });
+    await expect(workspaceComponentLib.assertComponentInWorkspace('comp', 'ws1')).rejects.toMatchObject({ status: 404 });
+  });
+
+  test('refuse un composant sans id', async () => {
+    await expect(workspaceComponentLib.assertComponentInWorkspace(undefined, 'ws1')).rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/packages/core/lib/workspace_component_lib.js
+++ b/packages/core/lib/workspace_component_lib.js
@@ -19,7 +19,8 @@ module.exports = {
   get_all_withConsomation: _get_all_withConsomation,
   get_all: _get_all,
   remove: _remove,
-  get_component_result: _get_component_result
+  get_component_result: _get_component_result,
+  assertComponentInWorkspace: _assertComponentInWorkspace
 };
 
 // --------------------------------------------------------------------------------
@@ -143,6 +144,35 @@ async function _update(componentToUpdate) {
 } // <= _update
 
 // --------------------------------------------------------------------------------
+
+// SÉCURITÉ : vérifie qu'un composant appartient bien au workspace autorisé.
+// Utilisé par les routes PUT/DELETE /workspaces/:id/components pour empêcher
+// un confused deputy (autoriser sur req.params.id, écrire sur un body._id d'un
+// autre workspace). Lève une erreur si le composant n'existe pas ou n'appartient
+// pas au workspace donné.
+async function _assertComponentInWorkspace(componentId, workspaceId) {
+  if (!componentId) {
+    const err = new global.Error('component_not_found');
+    err.status = 404;
+    throw err;
+  }
+  const component = await workspaceComponentModel.getInstance().model
+    .findOne({ _id: componentId })
+    .select('workspaceId')
+    .lean()
+    .exec();
+  if (!component) {
+    const err = new global.Error('component_not_found');
+    err.status = 404;
+    throw err;
+  }
+  if (component.workspaceId && component.workspaceId.toString() !== workspaceId.toString()) {
+    const err = new global.Error('component_not_in_workspace');
+    err.status = 403;
+    throw err;
+  }
+  return component;
+} // <= _assertComponentInWorkspace
 
 async function _remove(componentToDelete) {
   const component = await workspaceComponentModel.getInstance().model.findOne({

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/core",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "description": "Core module for Semantic Bus",
   "private": true,
   "main": "index.js",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/engine",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "description": "Processing engine module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/eval-service/package.json
+++ b/packages/eval-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/eval-service",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "description": "Service d'évaluation JavaScript isolé en container (dédié aux eval des transformations / $where).",
   "private": true,
   "main": "app.js",

--- a/packages/main/__tests__/server/workspaceSecurity.test.js
+++ b/packages/main/__tests__/server/workspaceSecurity.test.js
@@ -7,10 +7,22 @@ jest.mock('../../server/services/security', () => ({
   wrapperSecurity: jest.fn((req, res, next, role, entity) => next())
 }));
 
-jest.mock('@semantic-bus/core/lib/workspace_lib', () => ({}));
+jest.mock('@semantic-bus/core/lib/workspace_lib', () => ({
+  update: jest.fn(() => Promise.resolve({ components: [] })),
+  getWorkspace: jest.fn(),
+  addConnection: jest.fn(),
+  get_workspace_simple: jest.fn(),
+  updateSimple: jest.fn()
+}));
 jest.mock('@semantic-bus/core', () => ({ user: {} }));
 jest.mock('@semantic-bus/core/lib/auth_lib', () => ({}));
-jest.mock('@semantic-bus/core/lib/workspace_component_lib', () => ({}));
+jest.mock('@semantic-bus/core/lib/workspace_component_lib', () => ({
+  create: jest.fn(() => Promise.resolve([])),
+  update: jest.fn(() => Promise.resolve({})),
+  remove: jest.fn(() => Promise.resolve({})),
+  assertComponentInWorkspace: jest.fn(() => Promise.resolve({ _id: 'comp', workspaceId: 'ws' })),
+  get: jest.fn()
+}));
 jest.mock('@semantic-bus/core/lib/fragment_lib_scylla', () => ({}));
 jest.mock('../../server/services/technicalComponentDirectory', () => ({}));
 
@@ -67,5 +79,72 @@ describe('workspaceWebService - autorisation par workspace (IDOR)', () => {
       expect(mw).toBeDefined();
       expect(routeProtected(mw)).toBe(true);
     }
+  });
+});
+
+describe('workspaceWebService - confused deputy sur les routes sœurs (SB-IDOR-2026-01)', () => {
+  const securityService = require('../../server/services/security');
+  const workspaceLib = require('@semantic-bus/core/lib/workspace_lib');
+  const workspaceComponentLib = require('@semantic-bus/core/lib/workspace_component_lib');
+
+  let routes;
+  function makeRouter() {
+    const store = { post: {}, put: {}, delete: {}, get: {} };
+    return {
+      post: (path, ...mw) => { store.post[path] = mw; },
+      put: (path, ...mw) => { store.put[path] = mw; },
+      delete: (path, ...mw) => { store.delete[path] = mw; },
+      get: (path, ...mw) => { store.get[path] = mw; },
+      store
+    };
+  }
+
+  beforeEach(() => {
+    securityService.wrapperSecurity.mockClear();
+    jest.clearAllMocks();
+    routes = makeRouter();
+    registerRoutes(routes);
+  });
+
+  test('PUT /workspaces/:id lie la cible d écriture à req.params.id', async () => {
+    const mw = routes.store.put['/workspaces/:id'];
+    const req = { params: { id: 'WS_AUTHORIZED' }, body: { _id: 'WS_ATTACKER', name: 'PWNED' } };
+    const res = { send: jest.fn() };
+    const next = jest.fn();
+    await mw[1](req, res, next);
+    // le body._id doit être écrasé par req.params.id (pas de confused deputy)
+    expect(workspaceLib.update).toHaveBeenCalledWith(expect.objectContaining({ _id: 'WS_AUTHORIZED' }));
+    expect(req.body._id).toBe('WS_AUTHORIZED');
+  });
+
+  test('PUT /workspaces/:id/components vérifie l appartenance du composant au workspace', async () => {
+    const mw = routes.store.put['/workspaces/:id/components'];
+    const req = { params: { id: 'WS_AUTHORIZED' }, body: { _id: 'COMP_X', name: 'x' } };
+    const res = { json: jest.fn() };
+    const next = jest.fn();
+    await mw[1](req, res, next);
+    expect(workspaceComponentLib.assertComponentInWorkspace).toHaveBeenCalledWith('COMP_X', 'WS_AUTHORIZED');
+    expect(workspaceComponentLib.update).toHaveBeenCalled();
+  });
+
+  test('DELETE /workspaces/:id/components vérifie l appartenance du composant au workspace', async () => {
+    const mw = routes.store.delete['/workspaces/:id/components'];
+    const req = { params: { id: 'WS_AUTHORIZED' }, body: { _id: 'COMP_X' } };
+    const res = { json: jest.fn() };
+    const next = jest.fn();
+    await mw[1](req, res, next);
+    expect(workspaceComponentLib.assertComponentInWorkspace).toHaveBeenCalledWith('COMP_X', 'WS_AUTHORIZED');
+    expect(workspaceComponentLib.remove).toHaveBeenCalledWith({ _id: 'COMP_X' });
+  });
+
+  test('DELETE /workspaces/:id/components propage l erreur si composant hors workspace', async () => {
+    const mw = routes.store.delete['/workspaces/:id/components'];
+    workspaceComponentLib.assertComponentInWorkspace.mockRejectedValueOnce(new Error('component_not_in_workspace'));
+    const req = { params: { id: 'WS_AUTHORIZED' }, body: { _id: 'COMP_X' } };
+    const res = { json: jest.fn() };
+    const next = jest.fn();
+    await mw[1](req, res, next);
+    expect(workspaceComponentLib.remove).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
   });
 });

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/main",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "description": "Main application module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/main/server/workspaceWebService.js
+++ b/packages/main/server/workspaceWebService.js
@@ -362,14 +362,20 @@ module.exports = function (router) {
 
   // --------------------------------------------------------------------------------
 
-  router.delete('/workspaces/:id/components', (req, res, next) => securityService.wrapperSecurity(req, res, next,undefined,'workflow'), function (req, res, next) {
-    workspace_component_lib.remove({
-      _id: req.body._id
-    }).then(() => {
+  router.delete('/workspaces/:id/components', (req, res, next) => securityService.wrapperSecurity(req, res, next,undefined,'workflow'), async function (req, res, next) {
+    try {
+      // SÉCURITÉ : le composant cible doit appartenir au workspace autorisé (req.params.id).
+      await workspace_component_lib.assertComponentInWorkspace(req.body._id, req.params.id)
+      await workspace_component_lib.remove({
+        _id: req.body._id
+      })
       res.json(req.body)
-    }).catch(e => {
+    } catch (e) {
+      if (e && e.status) {
+        return res.status(e.status).send({ success: false, message: e.message || 'Forbidden' })
+      }
       next(e)
-    })
+    }
   })// <= delete_components #share
 
   // ---------------------------------------------------------------------------------
@@ -384,12 +390,21 @@ module.exports = function (router) {
 
   // --------------------------------------------------------------------------------
 
-  router.put('/workspaces/:id/components', (req, res, next) => securityService.wrapperSecurity(req, res, next,undefined,'workflow'), function (req, res, next) {
-    workspace_component_lib.update(req.body)
-      .then((componentUpdated) => (res.json(componentUpdated)))
-      .catch(e => {
-        next(e)
-      })
+  router.put('/workspaces/:id/components', (req, res, next) => securityService.wrapperSecurity(req, res, next,undefined,'workflow'), async function (req, res, next) {
+    try {
+      // SÉCURITÉ : le composant cible doit appartenir au workspace autorisé (req.params.id).
+      if (req.body && req.body._id) {
+        await workspace_component_lib.assertComponentInWorkspace(req.body._id, req.params.id)
+        req.body.workspaceId = req.params.id
+      }
+      const componentUpdated = await workspace_component_lib.update(req.body)
+      res.json(componentUpdated)
+    } catch (e) {
+      if (e && e.status) {
+        return res.status(e.status).send({ success: false, message: e.message || 'Forbidden' })
+      }
+      next(e)
+    }
   })// <= update_component #share
 
   // --------------------------------------------------------------------------------
@@ -471,6 +486,9 @@ module.exports = function (router) {
 
   router.put('/workspaces/:id', (req, res, next) => securityService.wrapperSecurity(req, res, next,undefined,'workflow'), function (req, res, next) {
     if (req.body != null) {
+      // SÉCURITÉ : lier la cible d'écriture au workspace autorisé par wrapperSecurity.
+      // Ne jamais autoriser sur req.params.id et écrire sur req.body._id (confused deputy).
+      req.body._id = req.params.id
       workspace_lib.update(req.body).then(workspaceUpdate => {
         for (var c of workspaceUpdate.components) {
           if (technicalComponentDirectory[c.module] != null) {

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/timer",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "description": "Timer scheduler module for Semantic Bus",
   "private": true,
   "main": "app.js",


### PR DESCRIPTION
## Résumé

Correctif de la faille signalée par Maxim Yakovlev dans son commentaire sur le GHSA IDOR
(2026-08-24) : **même classe d'accès** que l'import, encore ouverte sur les routes sœurs.

## Faille

Les routes autorisent sur `req.params.id` (`wrapperSecurity`) mais écrivent sur
`req.body._id` (**jamais vérifié**) → **confused deputy** :
- `PUT /workspaces/:id` → `findOneAndUpdate({_id: body._id}, body, {upsert:true})` :
  **cross-tenant overwrite + ownership takeover** (le body contient `users[]`).
- `PUT /workspaces/:id/components` → update/création arbitraire de composants.
- `DELETE /workspaces/:id/components` → suppression arbitraire de composants.

## Correctif

- `PUT /workspaces/:id` : **`req.body._id = req.params.id`** avant `workspace_lib.update`.
- `PUT`/`DELETE /workspaces/:id/components` : **`assertComponentInWorkspace`** — le
  composant cible doit appartenir au workspace autorisé (403 si hors workspace, 404 si
  inexistant) ; `workspaceId` forcé sur l'update.

## Tests

- `workspaceSecurity.test.js` : 4 nouveaux tests (cible liée, appartenance composant).
- `workspace_component_security.test.js` : 4 tests `assertComponentInWorkspace`.
- **E2E réel** : Alice (owner d'ALICE_WS) ne peut plus écrire/supprimer sur BOB_WS/BOB_COMP
  (403), mais modifie son propre workspace (200). 0 erreur console.

**Release** : bump `v0.11.10` + CHANGELOG.