### PR TITLE
release: sync production to v0.11.11 (désactive bigdataflow legacy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.11.11] - 2026-08-24
+
+### Security
+
+- **Routes legacy `bigdataflow` désactivées** : fonctionnalité inutilisée (0 bigdataflow
+  en prod, front archivé). La route `PUT /bigdataflow/:id` présentait le même confused
+  deputy que les routes workspace (autoriser sur `req.params.id`, écrire sur
+  `req.body._id`). Le service n'est plus monté dans `app.js` (surface d'attaque fermée) ;
+  correctif de secours conservé dans le service.
+
 ## [0.11.10] - 2026-08-24
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-bus-monorepo",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "ETL style data middleware transformation embedded in an ESB for all kind of data",
   "private": true,
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/core",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "Core module for Semantic Bus",
   "private": true,
   "main": "index.js",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/engine",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "Processing engine module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/eval-service/package.json
+++ b/packages/eval-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/eval-service",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "Service d'évaluation JavaScript isolé en container (dédié aux eval des transformations / $where).",
   "private": true,
   "main": "app.js",

--- a/packages/main/app.js
+++ b/packages/main/app.js
@@ -48,7 +48,6 @@ app.use('/data', unSafeRouteur);
 require('./server/initialiseWebService')(unSafeRouteur);
 require('./server/authWebService')(unSafeRouteur);
 require('./server/workspaceWebService')(safe);
-require('./server/bigdataflowService')(safe);
 require('./server/adminWebService')(safe);
 const technicalComponentDirectory = require('./server/technicalComponentWebService')(safe, unSafeRouteur);
 require('./server/userWebservices')(safe);

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/main",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "Main application module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/main/server/bigdataflowService.js
+++ b/packages/main/server/bigdataflowService.js
@@ -165,6 +165,9 @@ module.exports = function (router) {
 
   router.put('/bigdataflow/:id', (req, res, next) => securityService.wrapperSecurity(req, res, next,undefined,'bigdataflow'), (req, res, next)=> {
     if (req.body != null) {
+      // SÉCURITÉ : lier la cible d'écriture au bigdataflow autorisé par wrapperSecurity.
+      // Ne jamais autoriser sur req.params.id et écrire sur req.body._id (confused deputy).
+      req.body._id = req.params.id
       bigdataflow_lib.update(req.body).then(workspaceUpdated => {
         res.send(workspaceUpdated)
       }).catch(e => {

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/timer",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "Timer scheduler module for Semantic Bus",
   "private": true,
   "main": "app.js",


### PR DESCRIPTION
## Résumé

Sync de `production` avec `master` → **v0.11.11**.

## Contenu

- **Désactivation des routes legacy `bigdataflow`** (inutilisées, confused deputy latent).
- Bump v0.11.11 + CHANGELOG.