### PR TITLE
fix(security): admin-only routes de maintenance + IDOR de lecture fichiers (SB-IDOR-2026-01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.11.12] - 2026-08-24
+
+### Security
+
+- **Routes de maintenance admin réservées aux admins** : `cleanGarbage`, `cleanProcess`,
+  `executeTimers` passent par `wrapperAdmin` (avant : tout user authentifié pouvait les
+  déclencher).
+- **IDOR de lecture sur les fichiers fermé** : `GET /file/:fileId` et `/download`
+  vérifient désormais que le user est **owner ou editor** du workflow lié au fichier
+  (via `processId` → `workflowId`), ou admin (403 sinon).
+
 ## [0.11.11] - 2026-08-24
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-bus-monorepo",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "description": "ETL style data middleware transformation embedded in an ESB for all kind of data",
   "private": true,
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/core",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "description": "Core module for Semantic Bus",
   "private": true,
   "main": "index.js",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/engine",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "description": "Processing engine module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/eval-service/package.json
+++ b/packages/eval-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/eval-service",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "description": "Service d'évaluation JavaScript isolé en container (dédié aux eval des transformations / $where).",
   "private": true,
   "main": "app.js",

--- a/packages/main/__tests__/server/adminWebServiceSecurity.test.js
+++ b/packages/main/__tests__/server/adminWebServiceSecurity.test.js
@@ -1,0 +1,52 @@
+// Test de sécurité — routes de maintenance admin (CWE-862)
+// Vérifie que cleanGarbage/cleanProcess/executeTimers passent par wrapperAdmin.
+
+jest.mock('../../server/services/security', () => ({
+  wrapperAdmin: jest.fn((req, res, next) => next())
+}));
+jest.mock('@semantic-bus/core', () => ({
+  error: {},
+  workspace: {}
+}));
+
+const registerRoutes = require('../../server/adminWebService');
+
+describe('adminWebService - routes de maintenance réservées aux admins', () => {
+  const securityService = require('../../server/services/security');
+
+  let routes;
+  function makeRouter() {
+    const store = { post: {}, put: {}, delete: {}, get: {} };
+    return {
+      post: (path, ...mw) => { store.post[path] = mw; },
+      put: (path, ...mw) => { store.put[path] = mw; },
+      delete: (path, ...mw) => { store.delete[path] = mw; },
+      get: (path, ...mw) => { store.get[path] = mw; },
+      store
+    };
+  }
+
+  function routeHasWrapperAdmin(mw) {
+    securityService.wrapperAdmin.mockClear();
+    const req = { params: {}, body: {} };
+    const res = {};
+    const next = jest.fn();
+    mw[0](req, res, next);
+    return securityService.wrapperAdmin.mock.calls.length > 0;
+  }
+
+  beforeEach(() => {
+    securityService.wrapperAdmin.mockClear();
+    routes = makeRouter();
+    registerRoutes(routes);
+  });
+
+  test('chaque route de maintenance passe par wrapperAdmin', () => {
+    const paths = ['/cleanGarbageSimple', '/cleanGarbage', '/cleanProcess', '/executeTimers'];
+    for (const path of paths) {
+      const mw = routes.store.post[path];
+      expect(mw).toBeDefined();
+      expect(routeHasWrapperAdmin(mw)).toBe(true);
+    }
+  });
+});

--- a/packages/main/__tests__/server/fileWebservicesSecurity.test.js
+++ b/packages/main/__tests__/server/fileWebservicesSecurity.test.js
@@ -1,0 +1,118 @@
+// Test de sécurité — IDOR de lecture fichiers (CWE-639)
+// Vérifie que GET /file/:fileId et /download vérifient l'accès au workspace du process.
+
+jest.mock('@semantic-bus/core/lib/file_lib_scylla', () => ({
+  get: jest.fn()
+}));
+jest.mock('@semantic-bus/core/models', () => {
+  const findOne = jest.fn();
+  return {
+    __findOne: findOne,
+    process: {
+      getInstance: jest.fn(() => ({ model: { findOne } }))
+    }
+  };
+});
+jest.mock('@semantic-bus/core/lib/auth_lib', () => ({
+  get_decoded_jwt: jest.fn()
+}));
+jest.mock('@semantic-bus/core/lib/user_lib', () => ({
+  getWithRelations: jest.fn()
+}));
+
+const fileLib = require('@semantic-bus/core/lib/file_lib_scylla');
+const models = require('@semantic-bus/core/models');
+const authLib = require('@semantic-bus/core/lib/auth_lib');
+const userLib = require('@semantic-bus/core/lib/user_lib');
+const registerRoutes = require('../../server/fileWebservices');
+
+const processFindOneMock = models.__findOne;
+
+describe('fileWebservices - accès fichier lié au workspace (IDOR de lecture)', () => {
+  let routes;
+  function makeRouter() {
+    const store = { post: {}, put: {}, delete: {}, get: {} };
+    return {
+      post: (path, ...mw) => { store.post[path] = mw; },
+      put: (path, ...mw) => { store.put[path] = mw; },
+      delete: (path, ...mw) => { store.delete[path] = mw; },
+      get: (path, ...mw) => { store.get[path] = mw; },
+      store
+    };
+  }
+
+  function callRoute(path, req) {
+    const mw = routes.store.get[path];
+    const res = { status: jest.fn(() => res), send: jest.fn(), setHeader: jest.fn() };
+    const next = jest.fn();
+    mw[0](req, res, next);
+    return { res, next };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    routes = makeRouter();
+    registerRoutes(routes);
+    authLib.get_decoded_jwt.mockReturnValue({ iss: 'u1' });
+  });
+
+  function mockFileWithProcess(processId) {
+    fileLib.get.mockResolvedValue({ processId, binary: 'data', filename: 'x.bin' });
+    processFindOneMock.mockReturnValue({
+      select: () => ({ lean: () => ({ exec: () => Promise.resolve({ workflowId: 'ws1' }) }) })
+    });
+  }
+
+  test('autorise un membre du workspace du process', async () => {
+    mockFileWithProcess('proc1');
+    userLib.getWithRelations.mockResolvedValue({
+      admin: false,
+      workspaces: [{ workspace: { _id: 'ws1' }, role: 'editor' }]
+    });
+    const req = { params: { fileId: 'f1' }, query: {}, headers: { authorization: 'JWT x' }, body: {} };
+    const { res } = callRoute('/file/:fileId', req);
+    await new Promise(r => setTimeout(r, 100));
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  test('refuse un non-membre du workspace du process (403)', async () => {
+    mockFileWithProcess('proc1');
+    userLib.getWithRelations.mockResolvedValue({
+      admin: false,
+      workspaces: [{ workspace: { _id: 'ws2' }, role: 'owner' }]
+    });
+    const req = { params: { fileId: 'f1' }, query: {}, headers: { authorization: 'JWT x' }, body: {} };
+    const { res } = callRoute('/file/:fileId', req);
+    await new Promise(r => setTimeout(r, 100));
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  test('autorise un admin', async () => {
+    mockFileWithProcess('proc1');
+    userLib.getWithRelations.mockResolvedValue({ admin: true, workspaces: [] });
+    const req = { params: { fileId: 'f1' }, query: {}, headers: { authorization: 'JWT x' }, body: {} };
+    const { res } = callRoute('/file/:fileId/download', req);
+    await new Promise(r => setTimeout(r, 100));
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  test('autorise un fichier cache sans process (JWT)', async () => {
+    fileLib.get.mockResolvedValue({ processId: null, binary: 'data' });
+    const req = { params: { fileId: 'f1' }, query: {}, headers: { authorization: 'JWT x' }, body: {} };
+    const { res } = callRoute('/file/:fileId', req);
+    await new Promise(r => setTimeout(r, 100));
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  test('refuse un membre du workspace avec un rôle non owner/editor', async () => {
+    mockFileWithProcess('proc1');
+    userLib.getWithRelations.mockResolvedValue({
+      admin: false,
+      workspaces: [{ workspace: { _id: 'ws1' }, role: 'viewer' }]
+    });
+    const req = { params: { fileId: 'f1' }, query: {}, headers: { authorization: 'JWT x' }, body: {} };
+    const { res } = callRoute('/file/:fileId', req);
+    await new Promise(r => setTimeout(r, 100));
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+});

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/main",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "description": "Main application module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/main/server/adminWebService.js
+++ b/packages/main/server/adminWebService.js
@@ -1,12 +1,13 @@
 var error_lib = require('@semantic-bus/core').error
 var workspace_lib = require('@semantic-bus/core').workspace
 var configuration = require('../config.json')
+var securityService = require('./services/security')
 
 //  ------------------------- THIS PART IS DISABLE FOR NOW  -------------------------------
 
 module.exports = function (router) {
 
-  router.post('/cleanGarbageSimple', function (req, res, next) {
+  router.post('/cleanGarbageSimple', (req, res, next) => securityService.wrapperAdmin(req, res, next), function (req, res, next) {
     workspace_lib.cleanGarbage().then(() => {
       res.send("well cleaned")
     }).catch(e => {
@@ -14,7 +15,7 @@ module.exports = function (router) {
     })
   })
 
-  router.post('/cleanGarbage', function (req, res, next) {
+  router.post('/cleanGarbage', (req, res, next) => securityService.wrapperAdmin(req, res, next), function (req, res, next) {
     workspace_lib.cleanGarbageForgotten().then(() => {
       res.send("well cleaned")
     }).catch(e => {
@@ -22,7 +23,7 @@ module.exports = function (router) {
     })
   })
 
-  router.post('/cleanProcess', async function (req, res, next) {
+  router.post('/cleanProcess', (req, res, next) => securityService.wrapperAdmin(req, res, next), async function (req, res, next) {
     try{
       await workspace_lib.cleanAllOldProcess();
       await workspace_lib.cleanGarbage();
@@ -39,7 +40,7 @@ module.exports = function (router) {
     // })
   })
 
-  router.post('/executeTimers', function (req, res, next) {
+  router.post('/executeTimers', (req, res, next) => securityService.wrapperAdmin(req, res, next), function (req, res, next) {
     // console.log("configuration",configuration);
     workspace_lib.executeAllTimers(configuration).then(() => {
       res.send("well executed")

--- a/packages/main/server/fileWebservices.js
+++ b/packages/main/server/fileWebservices.js
@@ -2,7 +2,40 @@
 
 var user_lib = require('@semantic-bus/core/lib/user_lib')
 var file_lib = require('@semantic-bus/core/lib/file_lib_scylla')
+var processModel = require('@semantic-bus/core/models').process
+var auth_lib_jwt = require('@semantic-bus/core/lib/auth_lib')
+var config = require('../config.json')
 
+// SÉCURITÉ : vérifie que le user (token) a accès au fichier.
+// Le fichier porte un processId → process → workflowId (workspace) ; on autorise
+// si le user est admin, ou owner/editor de ce workspace. Ferme l'IDOR de lecture
+// (tout user authentifié pouvait lire n'importe quel fichier par id).
+async function assertFileAccess(req, file) {
+  if (!file || !file.processId) return true // fichier cache sans process : accès JWT
+  const token = req.body.token || req.query.token || req.headers['authorization']
+  if (!token) return false
+  const decoded = auth_lib_jwt.get_decoded_jwt(token.substring(4, token.length))
+  if (!decoded || !decoded.iss) return false
+
+  const process = await processModel.getInstance().model
+    .findOne({ _id: file.processId })
+    .select('workflowId')
+    .lean()
+    .exec()
+    .catch(() => null)
+  if (!process || !process.workflowId) return false
+
+  const result = await user_lib.getWithRelations(decoded.iss, config)
+  if (!result) return false
+  if (result.admin) return true
+  const workspaceId = process.workflowId.toString()
+  // Accès réservé aux owners/editors du workspace du workflow lié au fichier.
+  return (result.workspaces || []).some(w =>
+    w.workspace && w.workspace._id &&
+    w.workspace._id.toString() === workspaceId &&
+    (w.role === 'owner' || w.role === 'editor')
+  )
+}
 
 module.exports = function (router) {
   // router.delete('/files/:fileId', async (req, res, next) => {
@@ -17,6 +50,10 @@ module.exports = function (router) {
   router.get('/file/:fileId', async (req, res, next) => {
     try {
       let file = await file_lib.get(req.params.fileId)
+      const allowed = await assertFileAccess(req, file)
+      if (!allowed) {
+        return res.status(403).send({ success: false, message: 'No right' })
+      }
       res.send(file);
     } catch (error) {
       next(error)
@@ -25,6 +62,10 @@ module.exports = function (router) {
   router.get('/file/:fileId/download', async (req, res, next) => {
     try {
       let file = await file_lib.get(req.params.fileId);
+      const allowed = await assertFileAccess(req, file)
+      if (!allowed) {
+        return res.status(403).send({ success: false, message: 'No right' })
+      }
       res.setHeader('Content-Type', 'application/octet-stream');
       res.send(file.binary);
     } catch (error) {

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/timer",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "description": "Timer scheduler module for Semantic Bus",
   "private": true,
   "main": "app.js",


### PR DESCRIPTION
## Résumé

Audit de sécurité suite au retour du chercheur : **2 problèmes restants** de la classe
d'accès, corrigés dans cette **unique PR**.

## Correctifs

### 1. Routes de maintenance admin accessibles à tout user authentifié (CWE-862)
`adminWebService` (cleanGarbage, cleanProcess, executeTimers) était monté sur le routeur
`safe` (JWT) **sans `wrapperAdmin`** → n'importe quel user authentifié pouvait déclencher
ces actions sensibles. Les 4 routes passent désormais par `wrapperAdmin`.

### 2. IDOR de lecture sur les fichiers (CWE-639)
`GET /file/:fileId` et `/download` retournaient n'importe quel fichier par id, à tout user
authentifié. Désormais l'accès vérifie que le user est **owner ou editor** du **workflow
lié au fichier** (`processId` → `workflowId` → rôle du user dans le workspace), ou **admin**
(403 sinon).

## Tests

- `adminWebServiceSecurity.test.js` : les 4 routes passent par `wrapperAdmin`.
- `fileWebservicesSecurity.test.js` : membre autorisé, non-membre 403, admin autorisé,
  fichier cache sans process (JWT), rôle non-owner/editor refusé.
- **E2E réel** : cleanGarbage/executeTimers non-admin → 403, admin → OK ; GET /file →
  admin 200, owner 200, non-membre non-admin **403**.

**Release** : bump `v0.11.12` + CHANGELOG.