### PR TITLE
fix(security): upload réservé aux owner/editor du workflow + fichiers liés au workspace (SB-IDOR-2026-01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.11.13] - 2026-08-24
+
+### Security
+
+- **Upload de fichier réservé aux owner/editor du workflow** : `POST /upload/:compId`
+  vérifie que l'appelant est owner/editor du workspace du composant cible (ou admin),
+  403 sinon.
+- **Fichiers upload liés au workspace** : le `workspaceId` est stocké sur le fichier
+  (Scylla) à l'upload ; `GET /file/:fileId` et `/download` vérifient l'accès via le
+  `workspaceId` pour les fichiers sans `processId` (owner/editor, ou admin).
+
 ## [0.11.12] - 2026-08-24
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-bus-monorepo",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "description": "ETL style data middleware transformation embedded in an ESB for all kind of data",
   "private": true,
   "workspaces": [

--- a/packages/core/db/scylla_admin.js
+++ b/packages/core/db/scylla_admin.js
@@ -28,7 +28,8 @@ const createFileTable = async() => {
     'ALTER TABLE mykeyspace.file ADD frag UUID',
     'ALTER TABLE mykeyspace.file ADD filename text',
     'ALTER TABLE mykeyspace.file ADD cacheId text',
-    'ALTER TABLE mykeyspace.file ADD processId text'
+    'ALTER TABLE mykeyspace.file ADD processId text',
+    'ALTER TABLE mykeyspace.file ADD workspaceId text'
   ];
 
   try {

--- a/packages/core/model_schemas/file_schema_scylla.js
+++ b/packages/core/model_schemas/file_schema_scylla.js
@@ -8,7 +8,8 @@ class File {
       binary: data?.binary,
       filename: data?.filename,
       processId: data?.processId || data?.processid,
-      cacheId: data?.cacheId || data?.cacheid
+      cacheId: data?.cacheId || data?.cacheid,
+      workspaceId: data?.workspaceId || data?.workspaceid
     };
 
     this.id = lowerCamelData.id || uuidv4();
@@ -16,6 +17,7 @@ class File {
     this.filename = lowerCamelData.filename;
     this.processId = lowerCamelData.processId?.toString(); // This field is exclusive to the cacheId field
     this.cacheId = lowerCamelData.cacheId?.toString(); //   This field is exclusive to the processId field
+    this.workspaceId = lowerCamelData.workspaceId?.toString(); // workspace du fichier (upload)
   }
 }
 

--- a/packages/core/models/file_model_scylla.js
+++ b/packages/core/models/file_model_scylla.js
@@ -10,8 +10,8 @@ const insertFile = async(file) => {
     throw new Error(`The file is too large (${(file.binary.length / 1024 / 1024).toFixed(2)}MB). The maximum allowed size is 15MB.`);
   }
   const query = `
-    INSERT INTO file (id, binary, frag, filename, processId, cacheId)
-    VALUES (?, ?, ?, ?, ?, ?)
+    INSERT INTO file (id, binary, frag, filename, processId, cacheId, workspaceId)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
   `;
   const insertResult = await client.execute(query, [
     file.id,
@@ -19,7 +19,8 @@ const insertFile = async(file) => {
     file.frag,
     file.filename,
     file.processId,
-    file.cacheId
+    file.cacheId,
+    file.workspaceId
   ], {
     prepare: true
   });
@@ -97,7 +98,7 @@ const getAllFiles = async(query, params) => {
 const updateFile = async(file) => {
   const query = `
     UPDATE file 
-    SET binary = ?, filename = ?, processId = ?, cacheId = ?
+    SET binary = ?, filename = ?, processId = ?, cacheId = ?, workspaceId = ?
     WHERE id = ?
   `;
 
@@ -106,6 +107,7 @@ const updateFile = async(file) => {
     file.filename !== undefined ? file.filename : null,
     file.processId !== undefined ? file.processId : null,
     file.cacheId !== undefined ? file.cacheId : null,
+    file.workspaceId !== undefined ? file.workspaceId : null,
     file.id
   ];
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/core",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "description": "Core module for Semantic Bus",
   "private": true,
   "main": "index.js",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/engine",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "description": "Processing engine module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/eval-service/package.json
+++ b/packages/eval-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/eval-service",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "description": "Service d'évaluation JavaScript isolé en container (dédié aux eval des transformations / $where).",
   "private": true,
   "main": "app.js",

--- a/packages/main/__tests__/server/fileWebservicesSecurity.test.js
+++ b/packages/main/__tests__/server/fileWebservicesSecurity.test.js
@@ -115,4 +115,29 @@ describe('fileWebservices - accès fichier lié au workspace (IDOR de lecture)',
     await new Promise(r => setTimeout(r, 100));
     expect(res.status).toHaveBeenCalledWith(403);
   });
+
+  test('autorise un fichier uploadé (workspaceId) pour un owner/editor du workspace', async () => {
+    // fichier upload : pas de processId mais un workspaceId
+    fileLib.get.mockResolvedValue({ processId: null, workspaceId: 'ws1', binary: 'data' });
+    userLib.getWithRelations.mockResolvedValue({
+      admin: false,
+      workspaces: [{ workspace: { _id: 'ws1' }, role: 'editor' }]
+    });
+    const req = { params: { fileId: 'f1' }, query: {}, headers: { authorization: 'JWT x' }, body: {} };
+    const { res } = callRoute('/file/:fileId', req);
+    await new Promise(r => setTimeout(r, 100));
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  test('refuse un fichier uploadé (workspaceId) pour un non-membre du workspace', async () => {
+    fileLib.get.mockResolvedValue({ processId: null, workspaceId: 'ws1', binary: 'data' });
+    userLib.getWithRelations.mockResolvedValue({
+      admin: false,
+      workspaces: [{ workspace: { _id: 'ws2' }, role: 'owner' }]
+    });
+    const req = { params: { fileId: 'f1' }, query: {}, headers: { authorization: 'JWT x' }, body: {} };
+    const { res } = callRoute('/file/:fileId', req);
+    await new Promise(r => setTimeout(r, 100));
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
 });

--- a/packages/main/__tests__/server/uploadSecurity.test.js
+++ b/packages/main/__tests__/server/uploadSecurity.test.js
@@ -1,0 +1,70 @@
+// Test de sécurité — upload.js : l'upload d'un fichier exige owner/editor du workspace
+// du composant cible (ou admin).
+
+jest.mock('@semantic-bus/core/lib/file_lib_scylla', () => ({ create: jest.fn() }));
+jest.mock('@semantic-bus/core/models/file_model_scylla', () => ({ model: class {} }));
+jest.mock('@semantic-bus/core/lib/hmac_lib', () => ({ signMessage: jest.fn() }));
+jest.mock('@semantic-bus/core/lib/auth_lib', () => ({ get_decoded_jwt: jest.fn() }));
+jest.mock('@semantic-bus/core/lib/user_lib', () => ({ getWithRelations: jest.fn() }));
+jest.mock('@semantic-bus/core/lib/workspace_component_lib', () => ({ get: jest.fn() }));
+jest.mock('busboy', () => jest.fn(() => ({ on: jest.fn() })));
+jest.mock('fs', () => ({}));
+jest.mock('path', () => ({}));
+jest.mock('@semantic-bus/core/dataTraitmentLibrary/file_convertor.js', () => ({}));
+jest.mock('../../server/utils/propertyNormalizer.js', () => ({}));
+jest.mock('stream', () => ({ Readable: class {} }));
+
+const authLib = require('@semantic-bus/core/lib/auth_lib');
+const userLib = require('@semantic-bus/core/lib/user_lib');
+const componentLib = require('@semantic-bus/core/lib/workspace_component_lib');
+const upload = require('../../server/workspaceComponentInitialize/upload.js');
+
+describe('upload.assertUploadAccess - upload réservé aux owner/editor du workflow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authLib.get_decoded_jwt.mockReturnValue({ iss: 'u1' });
+  });
+
+  test('autorise un owner/editor du workspace du composant', async () => {
+    componentLib.get.mockResolvedValue({ _id: 'comp1', workspaceId: 'ws1' });
+    userLib.getWithRelations.mockResolvedValue({
+      admin: false,
+      workspaces: [{ workspace: { _id: 'ws1' }, role: 'editor' }]
+    });
+    const ws = await upload.assertUploadAccess({ headers: { authorization: 'JWT x' }, query: {}, body: {} }, 'comp1');
+    expect(ws).toBe('ws1');
+  });
+
+  test('refuse un non-membre du workspace (null)', async () => {
+    componentLib.get.mockResolvedValue({ _id: 'comp1', workspaceId: 'ws1' });
+    userLib.getWithRelations.mockResolvedValue({
+      admin: false,
+      workspaces: [{ workspace: { _id: 'ws2' }, role: 'owner' }]
+    });
+    const ws = await upload.assertUploadAccess({ headers: { authorization: 'JWT x' }, query: {}, body: {} }, 'comp1');
+    expect(ws).toBe(null);
+  });
+
+  test('autorise un admin', async () => {
+    componentLib.get.mockResolvedValue({ _id: 'comp1', workspaceId: 'ws1' });
+    userLib.getWithRelations.mockResolvedValue({ admin: true, workspaces: [] });
+    const ws = await upload.assertUploadAccess({ headers: { authorization: 'JWT x' }, query: {}, body: {} }, 'comp1');
+    expect(ws).toBe('ws1');
+  });
+
+  test('refuse si le composant n existe pas', async () => {
+    componentLib.get.mockRejectedValue(new Error('not found'));
+    const ws = await upload.assertUploadAccess({ headers: { authorization: 'JWT x' }, query: {}, body: {} }, 'comp1');
+    expect(ws).toBe(null);
+  });
+
+  test('refuse un rôle non owner/editor', async () => {
+    componentLib.get.mockResolvedValue({ _id: 'comp1', workspaceId: 'ws1' });
+    userLib.getWithRelations.mockResolvedValue({
+      admin: false,
+      workspaces: [{ workspace: { _id: 'ws1' }, role: 'viewer' }]
+    });
+    const ws = await upload.assertUploadAccess({ headers: { authorization: 'JWT x' }, query: {}, body: {} }, 'comp1');
+    expect(ws).toBe(null);
+  });
+});

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/main",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "description": "Main application module for Semantic Bus",
   "private": true,
   "main": "app.js",

--- a/packages/main/server/fileWebservices.js
+++ b/packages/main/server/fileWebservices.js
@@ -11,24 +11,32 @@ var config = require('../config.json')
 // si le user est admin, ou owner/editor de ce workspace. Ferme l'IDOR de lecture
 // (tout user authentifié pouvait lire n'importe quel fichier par id).
 async function assertFileAccess(req, file) {
-  if (!file || !file.processId) return true // fichier cache sans process : accès JWT
+  if (!file) return false
   const token = req.body.token || req.query.token || req.headers['authorization']
   if (!token) return false
   const decoded = auth_lib_jwt.get_decoded_jwt(token.substring(4, token.length))
   if (!decoded || !decoded.iss) return false
 
-  const process = await processModel.getInstance().model
-    .findOne({ _id: file.processId })
-    .select('workflowId')
-    .lean()
-    .exec()
-    .catch(() => null)
-  if (!process || !process.workflowId) return false
+  // Déterminer le workspace du fichier : via processId (flux) ou workspaceId (upload).
+  let workspaceId = null
+  if (file.processId) {
+    const process = await processModel.getInstance().model
+      .findOne({ _id: file.processId })
+      .select('workflowId')
+      .lean()
+      .exec()
+      .catch(() => null)
+    if (!process || !process.workflowId) return false
+    workspaceId = process.workflowId.toString()
+  } else if (file.workspaceId) {
+    workspaceId = file.workspaceId.toString()
+  } else {
+    return true // fichier cache legacy sans lien : accès JWT
+  }
 
   const result = await user_lib.getWithRelations(decoded.iss, config)
   if (!result) return false
   if (result.admin) return true
-  const workspaceId = process.workflowId.toString()
   // Accès réservé aux owners/editors du workspace du workflow lié au fichier.
   return (result.workspaces || []).some(w =>
     w.workspace && w.workspace._id &&

--- a/packages/main/server/workspaceComponentInitialize/upload.js
+++ b/packages/main/server/workspaceComponentInitialize/upload.js
@@ -6,6 +6,9 @@ const busboy = require('busboy');
 const file_lib = require('@semantic-bus/core/lib/file_lib_scylla');
 const file_model_scylla = require('@semantic-bus/core/models/file_model_scylla');
 const hmac_lib = require('@semantic-bus/core/lib/hmac_lib');
+const auth_lib_jwt = require('@semantic-bus/core/lib/auth_lib');
+const user_lib = require('@semantic-bus/core/lib/user_lib');
+const config = require('../../config.json');
 
 class Upload {
   constructor() {
@@ -32,9 +35,36 @@ class Upload {
     this.amqpConnection = amqpConnection;
   }
 
+  // SÉCURITÉ : l'upload d'un fichier n'est autorisé que si l'appelant est
+  // owner ou editor du workspace auquel appartient le composant cible (compId),
+  // ou admin. Retourne le workspaceId du composant, ou null si non autorisé.
+  async assertUploadAccess(req, compId) {
+    const component = await this.workspace_component_lib.get({ _id: compId }).catch(() => null);
+    if (!component || !component.workspaceId) return null;
+    const workspaceId = component.workspaceId.toString();
+    const token = req.body.token || req.query.token || req.headers['authorization'];
+    if (!token) return null;
+    const decoded = auth_lib_jwt.get_decoded_jwt(token.substring(4, token.length));
+    if (!decoded || !decoded.iss) return null;
+    const result = await user_lib.getWithRelations(decoded.iss, config);
+    if (!result) return null;
+    if (result.admin) return workspaceId;
+    const member = (result.workspaces || []).find(w =>
+      w.workspace && w.workspace._id && w.workspace._id.toString() === workspaceId
+    );
+    if (member && (member.role === 'owner' || member.role === 'editor')) return workspaceId;
+    return null;
+  }
+
   initialise(router) {
-    router.post('/upload/:compId', (req, res, next) => {
+    router.post('/upload/:compId', async (req, res, next) => {
       const compId = req.params.compId;
+
+      // SÉCURITÉ : seul un owner/editor du workspace du composant (ou admin) peut uploader.
+      const workspaceId = await this.assertUploadAccess(req, compId);
+      if (!workspaceId) {
+        return res.status(403).send({ success: false, message: 'No right' });
+      }
 
       const busboyInstance = busboy({
         headers: req.headers
@@ -57,7 +87,8 @@ class Upload {
             const fileData = new file_model_scylla.model({
               binary: buffer, // Utiliser la chaîne hexadécimale ici
               filename: fileName,
-              frag: null // ou toute autre propriété dont vous avez besoin
+              frag: null, // ou toute autre propriété dont vous avez besoin
+              workspaceId
             });
 
             const file = await file_lib.create(fileData);

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-bus/timer",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "description": "Timer scheduler module for Semantic Bus",
   "private": true,
   "main": "app.js",


### PR DESCRIPTION
## Résumé

Un fichier ne doit pouvoir être uploadé que par un **owner/editor du workflow** du composant
cible, et l'accès en lecture des fichiers uploadés doit être lié au workspace.

## Correctifs

### 1. Upload protégé (CWE-862)
`POST /upload/:compId` (routeur safe) acceptait l'upload de tout user authentifié.
`assertUploadAccess` vérifie désormais que l'appelant est **owner/editor** du workspace du
composant cible (via `compId` → composant → `workspaceId`), ou **admin** (403 sinon).

### 2. Fichiers upload liés au workspace (CWE-639)
- `workspaceId` ajouté à la table Scylla `file` (+ modèle + insert/update).
- Stocké à l'upload.
- `assertFileAccess` : pour les fichiers **sans processId** (upload), vérifie l'accès via
  `workspaceId` (owner/editor ou admin) au lieu d'un accès JWT large.

## Tests

- `uploadSecurity.test.js` (5) : owner/editor autorisé, non-membre 403, admin autorisé,
  composant inexistant refusé, rôle non-owner/editor refusé.
- `fileWebservicesSecurity.test.js` : + 2 cas fichier uploadé (workspaceId) autorisé/refusé.
- **E2E réel** : upload owner → 200, non-membre → **403** ; lecture fichier upload → owner 200,
  non-membre **403**.

**Release** : bump `v0.11.13` + CHANGELOG.