### PR TITLE
docs: backfill des orphelins = migration one-shot (plus nécessaire ≥ v0.11.16)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,11 @@ test-eval:
 	EVAL_SERVICE_URL=http://localhost:8083 ENGINE_HMAC_SECRET=${ENGINE_HMAC_SECRET:-secret} npx jest packages/eval-service/__tests__/eval-service.integration.test.js
 
 # Backfill des composants sans workspaceId (orphelins) — SB-IDOR-2026-01.
-# À exécuter AVANT ou EN MÊME TEMPS que le déploiement du code fail-closed
-# (assertComponentInWorkspace), sinon les composants orphelins deviennent
-# non éditables/destructibles par personne (même leur propriétaire).
+# MIGRATION ONE-SHOT : plus nécessaire à partir de v0.11.16 (le fail-closed +
+# l'estampillage workspaceId sur POST /workspaces/ empêchent les nouveaux orphelins).
+# À exécuter une seule fois, au déploiement du code fail-closed, sinon les composants
+# orphelins existants deviennent non éditables/destructibles par personne (même leur
+# propriétaire). Idempotent — inutile de le relancer sur une instance déjà ≥ v0.11.16.
 # Lance le script dans le container main (config.local.json monté → base locale).
 backfill-orphans:
 	@docker compose ps --status running main >/dev/null 2>&1 || { echo "❌ Container main non démarré — démarrer d'abord (make up / docker-up)"; exit 1; }

--- a/advisories/SB-IDOR-2026-01/2026-08-idor-workspace-import.md
+++ b/advisories/SB-IDOR-2026-01/2026-08-idor-workspace-import.md
@@ -89,6 +89,9 @@ CVSS à calculer (probablement ~8.x : réseau + authentifié faible + impact él
   `POST /workspaces/` (corrige aussi le bug latent de rattachement des composants) et
   (2) un **backfill** des orphelins existants (`packages/main/scripts/backfillOrphanComponents.js`)
   — les 3 à déployer ensemble, sinon les orphelins deviennent non éditables/destructibles.
+  ⚠️ **Backfill = migration one-shot, plus nécessaire à partir de v0.11.16** (le fail-closed
+  + l'estampillage empêchent la création de nouveaux orphelins) ; à exécuter une seule fois
+  au déploiement de v0.11.16, idempotent.
 
 ## CWE
 - **CWE-639** : Authorization Bypass Through User-Controlled Key (IDOR)

--- a/packages/main/scripts/backfillOrphanComponents.js
+++ b/packages/main/scripts/backfillOrphanComponents.js
@@ -8,6 +8,14 @@
 // tourner AVANT ou EN MÊME TEMPS que le déploiement du code corrigé, pour que les
 // flux PUT/DELETE légitimes continuent de fonctionner.
 //
+// ⚠️ MIGRATION ONE-SHOT — PLUS NÉCESSAIRE À PARTIR DE v0.11.16.
+// Depuis v0.11.16 : le fail-closed + l'estampillage de workspaceId sur le chemin
+// embedded de POST /workspaces/ garantissent qu'aucun nouveau composant sans
+// workspaceId ne peut être créé. Ce script n'est donc utile que pour les instances
+// qui ont des orphelins pré-existants (créés avant v0.11.16) : il suffit de l'exécuter
+// une fois au déploiement de v0.11.16. Idempotent — sans danger de le relancer,
+// mais sur une instance déjà ≥ v0.11.16 il n'aura plus rien à faire.
+//
 // Principe : pour chaque composant sans workspaceId, on cherche le workspace qui le
 // référence dans sa liste `workspace.components` et on estampe workspaceId = workspace._id.
 // Les composants non retrouvés (vraiment orphelins) sont listés à la fin pour contrôle


### PR DESCRIPTION
Précision documentaire sur le backfill des composants orphelins (SB-IDOR-2026-01) :

- **** : en-tête précise que c'est une
  **migration one-shot**, plus nécessaire à partir de v0.11.16 (le fail-closed +
  l'estampillage sur `POST /workspaces/` empêchent les nouveaux orphelins), idempotente.
- **Makefile** : commentaire de la cible `backfill-orphans` aligné sur la même mention.
- **Advisory technique** : ajout de la mention one-shot ≥ v0.11.16.

Aucun changement de comportement.