### PR TITLE
fix(timer): use this.hmac_lib instead of bare hmac_lib (ReferenceError)

### DIFF
--- a/packages/core/timerScheduler.js
+++ b/packages/core/timerScheduler.js
@@ -33,7 +33,7 @@ module.exports = {
                 console.log(`--------------- execution ${workspace._id}-${c._id} status:${workspace.status} name:${workspace.name}`);
 
 
-                const workParams = hmac_lib.signMessage(c._id, {
+                const workParams = this.hmac_lib.signMessage(c._id, {
                   id: c._id
                 });
 


### PR DESCRIPTION
**Bug préexistant** (introduit en `3d408b80` 2026-08-18, refactor sécurité HMAC) : `packages/core/timerScheduler.js:36` appelait `hmac_lib.signMessage(...)` **nu** au lieu de `this.hmac_lib.signMessage(...)` (`hmac_lib` est une propriété du module, ligne 11).

Impact en prod : chaque exécution d'un composant timer planifié levait `ReferenceError: hmac_lib is not defined`, capturée par le `.catch` (ligne 70) → **les workflows planifiés ne tournaient plus** depuis le déploiement de ce commit.

Fix : `this.hmac_lib`. Une ligne. Hors périmètre SB-IDOR-2026-01.