### PR TITLE
chore: sync production ← master (fix timer hmac_lib)

### DIFF
--- a/packages/core/timerScheduler.js
+++ b/packages/core/timerScheduler.js
@@ -33,7 +33,7 @@ module.exports = {
                 console.log(`--------------- execution ${workspace._id}-${c._id} status:${workspace.status} name:${workspace.name}`);
 
 
-                const workParams = hmac_lib.signMessage(c._id, {
+                const workParams = this.hmac_lib.signMessage(c._id, {
                   id: c._id
                 });
 


### PR DESCRIPTION
Sync master → production : PR #500 (fix — `this.hmac_lib` dans timerScheduler.js, workflows planifiés de nouveau fonctionnels).